### PR TITLE
Fixed contest view & distance unit. Added a link to contest creation admin page on nav

### DIFF
--- a/home/models/dailywalk.py
+++ b/home/models/dailywalk.py
@@ -1,4 +1,5 @@
 from django.db import models
+from home.templatetags.format_helpers import m_to_mi
 
 
 # Event model
@@ -18,7 +19,7 @@ class DailyWalk(models.Model):
 
     @property
     def distance_in_miles(self):
-        return self.distance * 0.000621371
+        return m_to_mi(self.distance)
 
     # Auto populate the account field from the device field
     def save(self, *args, **kwargs):

--- a/home/models/dailywalk.py
+++ b/home/models/dailywalk.py
@@ -16,6 +16,10 @@ class DailyWalk(models.Model):
     created = models.DateTimeField(auto_now_add=True, help_text="Record creation timestamp")
     updated = models.DateTimeField(auto_now=True, help_text="Record updation timestamp")
 
+    @property
+    def distance_in_miles(self):
+        return self.distance * 0.000621371
+
     # Auto populate the account field from the device field
     def save(self, *args, **kwargs):
         self.account = self.device.account

--- a/home/models/intentionalwalk.py
+++ b/home/models/intentionalwalk.py
@@ -34,8 +34,8 @@ class IntentionalWalk(models.Model):
         return time.strftime("%Hh %Mm %Ss", time.gmtime(int(self.pause_time)))
 
     @property
-    def speed(self):
-        return (self.distance / ((self.end - self.start).total_seconds() - self.pause_time)) * 3600
+    def speed_mph(self):
+        return (self.distance * 0.000621371 / ((self.end - self.start).total_seconds() - self.pause_time)) * 3600
 
     # Auto populate the account field from the device field
     def save(self, *args, **kwargs):

--- a/home/models/intentionalwalk.py
+++ b/home/models/intentionalwalk.py
@@ -1,5 +1,6 @@
 import time
 from django.db import models
+from home.templatetags.format_helpers import m_to_mi
 
 
 class IntentionalWalk(models.Model):
@@ -34,8 +35,12 @@ class IntentionalWalk(models.Model):
         return time.strftime("%Hh %Mm %Ss", time.gmtime(int(self.pause_time)))
 
     @property
+    def distance_in_miles(self):
+        return m_to_mi(self.distance)
+
+    @property
     def speed_mph(self):
-        return (self.distance * 0.000621371 / ((self.end - self.start).total_seconds() - self.pause_time)) * 3600
+        return (self.distance_in_miles / ((self.end - self.start).total_seconds() - self.pause_time)) * 3600
 
     # Auto populate the account field from the device field
     def save(self, *args, **kwargs):

--- a/home/templates/home/base.html
+++ b/home/templates/home/base.html
@@ -49,6 +49,9 @@
         <li class="nav-item">
            <a class="nav-link" href="/intentionalwalks/">RecordedWalks</a>
         </li>
+        <li class="nav-item">
+           <a class="nav-link" href="/admin/home/contest/add/">AddContest</a>
+        </li>
           <li class="nav-item">
               <a class="nav-link" href="/admin/logout">Logout</a>
           </li>

--- a/home/templates/home/user_list.html
+++ b/home/templates/home/user_list.html
@@ -59,10 +59,10 @@
                 <td>{{appuser.account.device_set.count}}</td>
                 <td>{{appuser.num_dws}}</td>
                 <td>{{appuser.dw_steps}}</td>
-                <td>{{appuser.dw_distance|m_to_mi|floatformat}}</td>
+                <td>{{appuser.dw_distance|floatformat}}</td>
                 <td>{{appuser.num_rws}}</td>
                 <td>{{appuser.rw_steps}}</td>
-                <td>{{appuser.rw_distance|m_to_mi|floatformat}}</td>
+                <td>{{appuser.rw_distance|floatformat}}</td>
                 <td>{{appuser.rw_time|floatformat}}</td>
                 <td>{{appuser.rw_avg_speed|floatformat}}</td>
             </tr>

--- a/home/views/web/home.py
+++ b/home/views/web/home.py
@@ -10,6 +10,9 @@ from home.models import Account, Device, IntentionalWalk, DailyWalk
 START_DATE = datetime.date(2020, 4, 1)
 END_DATE = datetime.datetime.today().date()
 
+# Hacky fix to ensure distance is in miles
+def m_to_mi(value):
+    return value * 0.000621371
 
 # Home page view
 class HomeView(generic.TemplateView):
@@ -71,7 +74,7 @@ class HomeView(generic.TemplateView):
 
         # Get growth for mile
         mile_dist = {
-            date: sum([walk["distance"] for walk in group])
+            date: sum([m_to_mi(walk["distance"]) for walk in group])
             for date, group in itertools.groupby(daily_walks.values(), key=lambda x: x["date"])
         }
         # Fill the gaps cos google charts if annoying af

--- a/home/views/web/home.py
+++ b/home/views/web/home.py
@@ -5,14 +5,12 @@ from collections import Counter
 from django.views import View, generic
 
 from home.models import Account, Device, IntentionalWalk, DailyWalk
+from home.templatetags.format_helpers import m_to_mi
 
 # Date range for data aggregation
 START_DATE = datetime.date(2020, 4, 1)
 END_DATE = datetime.datetime.today().date()
 
-# Hacky fix to ensure distance is in miles
-def m_to_mi(value):
-    return value * 0.000621371
 
 # Home page view
 class HomeView(generic.TemplateView):

--- a/home/views/web/intentionalwalk.py
+++ b/home/views/web/intentionalwalk.py
@@ -6,14 +6,12 @@ from django.views import View, generic
 from django.db.models import Sum
 
 from home.models import Account, Device, IntentionalWalk, DailyWalk
+from home.templatetags.format_helpers import m_to_mi
 
 # Date range for data aggregation
 START_DATE = datetime.date(2020, 4, 1)
 END_DATE = datetime.datetime.today().date()
 
-# Hacky fix to ensure distance is in miles
-def m_to_mi(value):
-    return value * 0.000621371
 
 class IntentionalWalkWebView(generic.ListView):
     template_name = "home/iw_list.html"

--- a/home/views/web/intentionalwalk.py
+++ b/home/views/web/intentionalwalk.py
@@ -11,6 +11,9 @@ from home.models import Account, Device, IntentionalWalk, DailyWalk
 START_DATE = datetime.date(2020, 4, 1)
 END_DATE = datetime.datetime.today().date()
 
+# Hacky fix to ensure distance is in miles
+def m_to_mi(value):
+    return value * 0.000621371
 
 class IntentionalWalkWebView(generic.ListView):
     template_name = "home/iw_list.html"
@@ -33,7 +36,7 @@ class IntentionalWalkWebView(generic.ListView):
                 recorded_walks_stats[date]["count"] += 1  # Update count
                 recorded_walks_stats[date]["steps"] += obj["steps"]  # Update count
                 recorded_walks_stats[date]["time"] += (obj["end"] - obj["start"]).total_seconds() - obj["pause_time"]
-                recorded_walks_stats[date]["miles"] += obj["distance"]  # Update count
+                recorded_walks_stats[date]["miles"] += m_to_mi(obj["distance"])  # Update count
 
         # Fill the gaps cos google charts if annoying af
         current_date = START_DATE
@@ -67,7 +70,7 @@ class IntentionalWalkWebView(generic.ListView):
         context["percent_steps"] = (
             (context["total_iw_stats"]["steps"] / context["total_steps"]) * 100 if context["total_steps"] > 0 else 0
         )
-        context["total_distance"] = DailyWalk.objects.all().aggregate(Sum("distance"))["distance__sum"]
+        context["total_distance"] = m_to_mi(DailyWalk.objects.all().aggregate(Sum("distance"))["distance__sum"])
         context["percent_distance"] = (
             (context["total_iw_stats"]["miles"] / context["total_distance"]) * 100
             if context["total_distance"] > 0

--- a/home/views/web/user.py
+++ b/home/views/web/user.py
@@ -53,7 +53,7 @@ class UserListView(generic.ListView):
             user_stats["num_dws"] = len(daily_walks)
             for dw in daily_walks:
                 user_stats["dw_steps"] += dw.steps
-                user_stats["dw_distance"] += m_to_mi(dw.distance)
+                user_stats["dw_distance"] += dw.distance_in_miles
 
             # Get all recorded walk data
             user_stats["rw_steps"] = 0
@@ -63,7 +63,7 @@ class UserListView(generic.ListView):
             user_stats["num_rws"] = len(intentional_walks)
             for iw in intentional_walks:
                 user_stats["rw_steps"] += iw.steps
-                user_stats["rw_distance"] += m_to_mi(iw.distance)
+                user_stats["rw_distance"] += iw.distance_in_miles
                 user_stats["rw_time"] += iw.walk_time / 60
                 user_stats["rw_speeds"].append(iw.speed_mph)
             user_stats["rw_avg_speed"] = (

--- a/home/views/web/user.py
+++ b/home/views/web/user.py
@@ -4,6 +4,9 @@ from django.views import View, generic
 
 from home.models import Account, Contest
 
+# Hacky fix to ensure distance is in miles
+def m_to_mi(value):
+    return value * 0.000621371
 
 # User list page
 class UserListView(generic.ListView):
@@ -22,15 +25,14 @@ class UserListView(generic.ListView):
         if contest_id:
             # Get the contest associated with this id
             contest = Contest.objects.get(contest_id=contest_id)
-            accounts = contest.account_set.all()
             date_range_start = contest.start
             date_range_end = contest.end
             context["current_contest"] = contest
         else:
-            accounts = Account.objects.all()
             date_range_start = None
             date_range_end = None
 
+        accounts = Account.objects.all()
         context["user_stats_list"] = []
         for account in accounts:
             user_stats = {}
@@ -51,7 +53,7 @@ class UserListView(generic.ListView):
             user_stats["num_dws"] = len(daily_walks)
             for dw in daily_walks:
                 user_stats["dw_steps"] += dw.steps
-                user_stats["dw_distance"] += dw.distance
+                user_stats["dw_distance"] += m_to_mi(dw.distance)
 
             # Get all recorded walk data
             user_stats["rw_steps"] = 0
@@ -61,9 +63,9 @@ class UserListView(generic.ListView):
             user_stats["num_rws"] = len(intentional_walks)
             for iw in intentional_walks:
                 user_stats["rw_steps"] += iw.steps
-                user_stats["rw_distance"] += iw.distance
+                user_stats["rw_distance"] += m_to_mi(iw.distance)
                 user_stats["rw_time"] += iw.walk_time / 60
-                user_stats["rw_speeds"].append(iw.speed)
+                user_stats["rw_speeds"].append(iw.speed_mph)
             user_stats["rw_avg_speed"] = (
                 sum(user_stats["rw_speeds"]) / len(user_stats["rw_speeds"]) if user_stats["rw_speeds"] else 0
             )


### PR DESCRIPTION
1. Removed account filtering based on contest enrollment since enrollment is assumed by default. This should simply filter user stats by only the date range.
2. Hotfix to display all distances as miles instead of meters (initial assumption was that the distance unit would be miles)
3. Added link to the contest creation page on navbar.