### PR TITLE
New demographic info

### DIFF
--- a/home/migrations/0007_new_demographic_cols.py
+++ b/home/migrations/0007_new_demographic_cols.py
@@ -1,0 +1,68 @@
+from django.db import migrations, models
+from home.models.account import SAN_FRANCISCO_ZIP_CODES
+
+"""
+This migration adds new demographic fields into Account:
+ * is_latino: Latino/Hispanic origin
+ * is_sf_resident: whether the user is a SF resident or not (based on zip)
+
+It also creates a new table of Race (many-to-many relationship of users and races)
+"""
+
+def populate_is_sf_resident(apps, schema_editor):
+    Account = apps.get_model("home", "Account")
+    db_alias = schema_editor.connection.alias
+
+    for account in Account.objects.using(db_alias):
+        account.is_sf_resident = account.zip in SAN_FRANCISCO_ZIP_CODES
+        account.save()
+
+def depopulate_is_sf_resident(apps, schema_editor):
+    Account = apps.get_model("home", "Account")
+    db_alias = schema_editor.connection.alias
+
+    for account in Account.objects.using(db_alias):
+        account.is_sf_resident = None
+        account.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('home', '0006_auto_20200623_2207'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Race',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('label', models.CharField(max_length=75, unique=True)),
+            ],
+        ),
+        migrations.AddField(
+            model_name='account',
+            name='is_sf_resident',
+            field=models.BooleanField(help_text='Whether the user is a SF resident or not, based on zip', null=True),
+        ),
+        migrations.AddField(
+            model_name='account',
+            name='is_latino',
+            field=models.BooleanField(blank=True, help_text='Latino or Hispanic origin', null=True),
+        ),
+        migrations.AddField(
+            model_name='account',
+            name='race',
+            field=models.ManyToManyField(blank=True, help_text='Self-identified race(s) of user', to='home.Race'),
+        ),
+        migrations.AddField(
+            model_name='account',
+            name='gender',
+            field=models.CharField(blank=True, help_text='Self-identified gender identity of user', max_length=25),
+        ),
+        migrations.AddField(
+            model_name='account',
+            name='is_tester',
+            field=models.BooleanField(help_text='User is an app tester', default=False),
+        ),
+        migrations.RunPython(populate_is_sf_resident, reverse_code=depopulate_is_sf_resident),
+    ]

--- a/home/models/__init__.py
+++ b/home/models/__init__.py
@@ -3,3 +3,4 @@ from .account import Account
 from .dailywalk import DailyWalk
 from .intentionalwalk import IntentionalWalk
 from .contest import Contest
+from .race import Race

--- a/home/models/account.py
+++ b/home/models/account.py
@@ -13,6 +13,11 @@ class Account(models.Model):
     name = models.CharField(max_length=250, help_text="User's name")
     zip = models.CharField(max_length=25, help_text="User's zipcode")
     age = models.IntegerField(help_text="User's age")
+    is_latino = models.BooleanField(null=True, blank=True, help_text="Latino or Hispanic origin")
+    race = models.ManyToManyField("Race", blank=True, help_text="Self-identified race(s) of user")
+    gender = models.CharField(max_length=25, help_text="Self-identified gender identity of user")
+
+    is_tester = models.BooleanField(default=False, help_text="User is an app tester")
     contests = models.ManyToManyField("Contest", blank=True, help_text="All the contests the account has enrolled in")
     created = models.DateTimeField(auto_now_add=True, help_text="Accounts creation timestamp")
     updated = models.DateTimeField(auto_now=True, help_text="Accounts updation timestamp")

--- a/home/models/account.py
+++ b/home/models/account.py
@@ -1,5 +1,11 @@
 from django.db import models
 
+SAN_FRANCISCO_ZIP_CODES = set([
+    '94102', '94103', '94104', '94105', '94107', '94108', '94109', '94110',
+    '94111', '94112', '94114', '94115', '94116', '94117', '94118', '94121',
+    '94122', '94123', '94124', '94127', '94129', '94130', '94131', '94132',
+    '94133', '94134', '94158',
+])
 
 # Note: Maybe inherit from Django's User model?
 class Account(models.Model):
@@ -13,9 +19,10 @@ class Account(models.Model):
     name = models.CharField(max_length=250, help_text="User's name")
     zip = models.CharField(max_length=25, help_text="User's zipcode")
     age = models.IntegerField(help_text="User's age")
+    is_sf_resident = models.BooleanField(null=True, help_text="Whether the user is a SF resident or not, based on zip")
     is_latino = models.BooleanField(null=True, blank=True, help_text="Latino or Hispanic origin")
     race = models.ManyToManyField("Race", blank=True, help_text="Self-identified race(s) of user")
-    gender = models.CharField(max_length=25, help_text="Self-identified gender identity of user")
+    gender = models.CharField(max_length=25, blank=True, help_text="Self-identified gender identity of user")
 
     is_tester = models.BooleanField(default=False, help_text="User is an app tester")
     contests = models.ManyToManyField("Contest", blank=True, help_text="All the contests the account has enrolled in")

--- a/home/models/race.py
+++ b/home/models/race.py
@@ -1,0 +1,12 @@
+from django.db import models
+
+
+class Race(models.Model):
+    """
+    Simple table of racial identity options
+    """
+
+    label = models.CharField(unique=True, max_length=75)
+
+    def __str__(self):
+        return self.label

--- a/home/views/api/appuser.py
+++ b/home/views/api/appuser.py
@@ -6,6 +6,7 @@ from django.utils.decorators import method_decorator
 from django.core.exceptions import ObjectDoesNotExist
 
 from home.models import Account, Device
+from home.models.account import SAN_FRANCISCO_ZIP_CODES
 from .utils import validate_request_json
 
 # Except from csrf validation
@@ -47,6 +48,7 @@ class AppUserCreateView(View):
             device.account.name = json_data["name"]
             device.account.zip = json_data["zip"]
             device.account.age = json_data["age"]
+            device.account.is_sf_resident = json_data["zip"] in SAN_FRANCISCO_ZIP_CODES
             device.account.save()
 
             message = "Device & account updated successfully"
@@ -60,6 +62,7 @@ class AppUserCreateView(View):
                 account.name = json_data["name"]
                 account.zip = json_data["zip"]
                 account.age = json_data["age"]
+                account.is_sf_resident = json_data["zip"] in SAN_FRANCISCO_ZIP_CODES
                 account.save()
                 account_updated = True
             except ObjectDoesNotExist:
@@ -87,6 +90,7 @@ class AppUserCreateView(View):
                     "email": device.account.email,
                     "zip": device.account.zip,
                     "age": device.account.age,
+                    "is_sf_resident": device.account.is_sf_resident,
                     "account_id": device.device_id,
                 },
             }

--- a/home/views/web/user.py
+++ b/home/views/web/user.py
@@ -50,7 +50,7 @@ class UserListView(generic.ListView):
         for iw in intentional_walks:
             intentional_walks_by_acc[iw['account__email']].append(iw)
 
-        accounts = Account.objects.values('email','name','age','zip', 'created')
+        accounts = Account.objects.values('email','name','age','zip','is_sf_resident','created')
 
         context["user_stats_list"] = []
         zipcounts = defaultdict(lambda: 0)

--- a/server/settings.py
+++ b/server/settings.py
@@ -141,3 +141,5 @@ LOGGING = {
         },
     },
 }
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'


### PR DESCRIPTION
## Summary
Adds columns/fields to Account model:
* `is_sf_resident`: whether the user is an SF resident or not, based on zip code
* `is_latino`: whether the user identifies as being of Latino/Hispanic origin
* `race`: many-to-many self-identified racial groups
* `gender`: self-identified gender identity
* `is_tester`: user is an app tester

# Changes
- Adds new fields
- Adds migration to add new fields and backfill `is_sf_resident` based on zip
- Adds list (set) of SF zip codes
- Creates new Race model for many-to-many mapping of users to race

# Deploying
- Includes a reversible migration
- Safe to revert but may result in loss of new Account data