### PR TITLE
Add new and active fields to users table

### DIFF
--- a/home/views/web/user.py
+++ b/home/views/web/user.py
@@ -36,7 +36,7 @@ class UserListView(generic.ListView):
             logger.info(f"For contest id '{contest_id}':")
             logger.info(f"  daily walks: {len(daily_walks)}, intentional walks: {len(intentional_walks)}")
             context["current_contest"] = contest
-            context["download_url"] += f"?start_date={contest.start.isoformat()}&end_date={contest.end.isoformat()}"
+            context["download_url"] += f"?contest_id={contest_id}"
         else:
             daily_walks = DailyWalk.objects.all().values('account__email','steps','distance','date')
             intentional_walks = IntentionalWalk.objects.all().values('account__email','steps','distance','pause_time', 'start','end')


### PR DESCRIPTION
## Summary
- Add new_signup and active_during_contest fields in Downloaded CSV file

## Changes
- Revised if-clause to filter out non-users (previous users who were inactive during contest) from downloadable CSV
- Update param to contest_id to enable contest-specific filters

## Reverting
- Safe to revert
