### PR TITLE
Fix skipped test of current contest

### DIFF
--- a/home/models/contest.py
+++ b/home/models/contest.py
@@ -26,6 +26,8 @@ class Contest(models.Model):
 
     @staticmethod
     def active(for_date=None, strict=False):
+        # strict: for_date (today, in general) must fall within contest dates
+        # If strict is False, then find most recent contest (prior to for_date)
         today = datetime.date.today() if for_date is None else for_date
         contest = Contest.objects.filter(start_promo__lte=today, end__gte=today).order_by("start_promo").first()
         if contest is None and not strict:

--- a/home/models/contest.py
+++ b/home/models/contest.py
@@ -26,7 +26,8 @@ class Contest(models.Model):
 
     @staticmethod
     def active(for_date=None, strict=False):
-        # strict: for_date (today, in general) must fall within contest dates
+        # strict: for_date, which in general will be "today", must fall within contest dates,
+        #         starting on promo date, ending on end date.
         # If strict is False, then find most recent contest (prior to for_date)
         today = datetime.date.today() if for_date is None else for_date
         contest = Contest.objects.filter(start_promo__lte=today, end__gte=today).order_by("start_promo").first()

--- a/home/models/contest.py
+++ b/home/models/contest.py
@@ -25,10 +25,10 @@ class Contest(models.Model):
         ordering = ("-start",)
 
     @staticmethod
-    def active(for_date=None):
+    def active(for_date=None, strict=False):
         today = datetime.date.today() if for_date is None else for_date
         contest = Contest.objects.filter(start_promo__lte=today, end__gte=today).order_by("start_promo").first()
-        if contest is None:
+        if contest is None and not strict:
             # get the last contest
             contest = Contest.objects.filter(end__lt=today).order_by("-end").first()
         return contest

--- a/home/models/contest.py
+++ b/home/models/contest.py
@@ -25,8 +25,8 @@ class Contest(models.Model):
         ordering = ("-start",)
 
     @staticmethod
-    def active():
-        today = datetime.date.today()
+    def active(for_date=None):
+        today = datetime.date.today() if for_date is None else for_date
         contest = Contest.objects.filter(start_promo__lte=today, end__gte=today).order_by("start_promo").first()
         if contest is None:
             # get the last contest

--- a/home/models/dailywalk.py
+++ b/home/models/dailywalk.py
@@ -9,7 +9,7 @@ class DailyWalk(models.Model):
     account. It is always linked to the specific device identifier :model: `home.Device`
     """
 
-    date = models.DateField(help_text="The specific for which the steps are recorded for")
+    date = models.DateField(help_text="The specific date for which the steps are recorded for")
     steps = models.IntegerField(help_text="Number of steps recorded")
     distance = models.FloatField(help_text="Total distance covered")
     device = models.ForeignKey("Device", on_delete=models.CASCADE, help_text="Device the data is coming from")

--- a/home/models/dailywalk.py
+++ b/home/models/dailywalk.py
@@ -9,7 +9,7 @@ class DailyWalk(models.Model):
     account. It is always linked to the specific device identifier :model: `home.Device`
     """
 
-    date = models.DateField(help_text="The specific date for which the steps are recorded for")
+    date = models.DateField(help_text="The specific date for which the steps are recorded")
     steps = models.IntegerField(help_text="Number of steps recorded")
     distance = models.FloatField(help_text="Total distance covered")
     device = models.ForeignKey("Device", on_delete=models.CASCADE, help_text="Device the data is coming from")

--- a/home/tests/integration/contest/test_current.py
+++ b/home/tests/integration/contest/test_current.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest import skip
+from django.test import Client, TestCase
 from freezegun import freeze_time
 
 from home.models import Contest
@@ -27,7 +27,6 @@ class ApiTestCase(TestCase):
             response_data["message"], f"There are no contests", msg=fail_message,
         )
 
-    @skip # skipping because libfaketime is not quite working as expected
     def test_contest_current(self):
         # create a few contests
         contest1 = Contest()

--- a/home/tests/integration/contest/test_current.py
+++ b/home/tests/integration/contest/test_current.py
@@ -1,9 +1,6 @@
 import datetime
-import libfaketime
-
-from dateutil import parser
-from django.test import Client, TestCase
 from unittest import skip
+from freezegun import freeze_time
 
 from home.models import Contest
 
@@ -46,7 +43,7 @@ class ApiTestCase(TestCase):
         contest2.save()
 
         # before first promo starts, failure
-        with libfaketime.fake_time("2020-04-01 00:00:01"):
+        with freeze_time("2020-04-01"):
             response = self.client.get(path=self.url, content_type=self.content_type)
             # Check for a successful response by the server
             self.assertEqual(response.status_code, 200)
@@ -59,7 +56,7 @@ class ApiTestCase(TestCase):
             )
 
         # after promo starts for first contest
-        with libfaketime.fake_time("2020-04-28 00:00:01"):
+        with freeze_time("2020-04-28"):
             response = self.client.get(path=self.url, content_type=self.content_type)
             # Check for a successful response by the server
             self.assertEqual(response.status_code, 200)
@@ -73,7 +70,7 @@ class ApiTestCase(TestCase):
             self.assertEqual(response_data["payload"]["end"], "2020-05-31")
 
         # during first contest
-        with libfaketime.fake_time("2020-05-15 00:00:01"):
+        with freeze_time("2020-05-15"):
             response = self.client.get(path=self.url, content_type=self.content_type)
             # Check for a successful response by the server
             self.assertEqual(response.status_code, 200)
@@ -87,7 +84,7 @@ class ApiTestCase(TestCase):
             self.assertEqual(response_data["payload"]["end"], "2020-05-31")
 
         # after first contest, before promo starts for next
-        with libfaketime.fake_time("2020-06-14 00:00:01"):
+        with freeze_time("2020-06-14"):
             response = self.client.get(path=self.url, content_type=self.content_type)
             # Check for a successful response by the server
             self.assertEqual(response.status_code, 200)
@@ -101,7 +98,7 @@ class ApiTestCase(TestCase):
             self.assertEqual(response_data["payload"]["end"], "2020-05-31")
 
         # after promo starts for next
-        with libfaketime.fake_time("2020-06-28 00:00:01"):
+        with freeze_time("2020-06-28"):
             response = self.client.get(path=self.url, content_type=self.content_type)
             # Check for a successful response by the server
             self.assertEqual(response.status_code, 200)
@@ -115,7 +112,7 @@ class ApiTestCase(TestCase):
             self.assertEqual(response_data["payload"]["end"], "2020-07-31")
 
         # after last contest
-        with libfaketime.fake_time("2020-08-14 00:00:01"):
+        with freeze_time("2020-08-14"):
             response = self.client.get(path=self.url, content_type=self.content_type)
             # Check for a successful response by the server
             self.assertEqual(response.status_code, 200)

--- a/home/tests/integration/dailywalk/test_create.py
+++ b/home/tests/integration/dailywalk/test_create.py
@@ -38,26 +38,26 @@ class ApiTestCase(TestCase):
         # Request parameters
         self.request_params = {
             "account_id": "12345",
-            "daily_walks": [{"date": "2020-02-22", "steps": 500, "distance": 1.3}],
+            "daily_walks": [{"date": "3000-02-22", "steps": 500, "distance": 1.3}],
         }
         self.bulk_request_params = {
             "account_id": "12345",
             "daily_walks": [
-                {"date": "2020-02-21", "steps": 1500, "distance": 2.1},
-                {"date": "2020-02-22", "steps": 500, "distance": 0.8},
-                {"date": "2020-02-23", "steps": 1000, "distance": 1.4},
+                {"date": "3000-02-21", "steps": 1500, "distance": 2.1},
+                {"date": "3000-02-22", "steps": 500, "distance": 0.8},
+                {"date": "3000-02-23", "steps": 1000, "distance": 1.4},
             ],
         }
         # Content type
         self.content_type = "application/json"
 
-    # Test a successful creation of a daily walk
+    # Test a successful creation of a daily walk (within a contest)
     def test_create_dailywalk(self):
         # Create a contest
         contest = Contest()
-        contest.start_promo = "2020-02-01"
-        contest.start = "2020-02-01"
-        contest.end = "2020-02-28"
+        contest.start_promo = "3000-02-01"
+        contest.start = "3000-02-01"
+        contest.end = "3000-02-28"
         contest.save()
 
         # Verify that the user has no contests
@@ -99,9 +99,9 @@ class ApiTestCase(TestCase):
     def test_create_dailywalk_outside_contests(self):
         # Create a contest
         contest = Contest()
-        contest.start_promo = "2020-03-01"
-        contest.start = "2020-03-01"
-        contest.end = "2020-03-31"
+        contest.start_promo = "3000-03-01"
+        contest.start = "3000-03-01"
+        contest.end = "3000-03-31"
         contest.save()
 
         # Verify that the user has no contests

--- a/home/tests/unit/test_contest.py
+++ b/home/tests/unit/test_contest.py
@@ -2,7 +2,6 @@ from datetime import date, datetime
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from freezegun import freeze_time
-from unittest import skip
 
 from home.models import Account, Contest
 
@@ -98,53 +97,58 @@ class TestContest(TestCase):
     def test_active(self):
         # create a few contests
         contest1 = Contest()
-        contest1.start_promo = "2020-04-24"
-        contest1.start = "2020-05-01"
-        contest1.end = "2020-05-31"
+        contest1.start_promo = "3000-04-24"
+        contest1.start = "3000-05-01"
+        contest1.end = "3000-05-31"
         contest1.save()
 
         contest2 = Contest()
-        contest2.start_promo = "2020-06-21"
-        contest2.start = "2020-07-01"
-        contest2.end = "2020-07-31"
+        contest2.start_promo = "3000-06-21"
+        contest2.start = "3000-07-01"
+        contest2.end = "3000-07-31"
         contest2.save()
 
+        # Helper function
         def _assertEqual(create_obj, db_obj):
             self.assertIsNotNone(db_obj)
             self.assertEqual(str(create_obj.pk), db_obj.pk)
 
         # before first promo starts, failure
-        with freeze_time("2020-04-01"):
+        with freeze_time("3000-04-01"):
             self.assertIsNone(Contest.active())
-        self.assertIsNone(Contest.active(for_date=date(2020,4,1)))
 
         # after promo starts for first contest
-        with freeze_time("2020-04-28"):
-            _assertEqual(contest1, Contest.active())
+        with freeze_time("3000-04-28"):
+            _assertEqual(contest1, Contest.active(for_date=date(3000,4,28)))
 
         # during first contest
-        with freeze_time("2020-05-15"):
+        with freeze_time("3000-05-15"):
             _assertEqual(contest1, Contest.active())
 
         # after first contest, before promo starts for next
-        with freeze_time("2020-06-14"):
+        with freeze_time("3000-06-14"):
             _assertEqual(contest1, Contest.active())
 
         # after promo starts for next
-        with freeze_time("2020-06-28"):
+        with freeze_time("3000-06-28"):
             _assertEqual(contest2, Contest.active())
 
         # after last contest
-        with freeze_time("2020-08-14"):
+        with freeze_time("3000-08-14"):
             _assertEqual(contest2, Contest.active())
 
         # Now test the same using Contest.active with `for_date`
         # instead of faking time
-        _assertEqual(contest1, Contest.active(for_date=date(2020,4,28)))
-        _assertEqual(contest1, Contest.active(for_date=date(2020,5,15)))
-        _assertEqual(contest1, Contest.active(for_date=date(2020,6,14)))
-        _assertEqual(contest2, Contest.active(for_date=date(2020,6,28)))
-        _assertEqual(contest2, Contest.active(for_date=date(2020,8,14)))
+        self.assertIsNone(Contest.active(for_date=date(3000,4,1)))
+
+        _assertEqual(contest1, Contest.active(for_date=date(3000,4,28)))
+        _assertEqual(contest1, Contest.active(for_date=date(3000,5,15)))
+        _assertEqual(contest1, Contest.active(for_date=date(3000,6,14)))
+        _assertEqual(contest2, Contest.active(for_date=date(3000,6,28)))
+        _assertEqual(contest2, Contest.active(for_date=date(3000,8,14)))
+
+        # Test with `strict`
+        self.assertIsNone(Contest.active(for_date=date(3000,8,14), strict=True))
 
     def test_associate_contest_with_account(self):
         contest = Contest.objects.create(

--- a/home/tests/unit/test_contest.py
+++ b/home/tests/unit/test_contest.py
@@ -1,7 +1,10 @@
+from datetime import date, datetime
 from django.core.exceptions import ValidationError
 from django.test import TestCase
+from freezegun import freeze_time
+from unittest import skip
 
-from home.models import Contest
+from home.models import Account, Contest
 
 
 class TestContest(TestCase):
@@ -91,3 +94,69 @@ class TestContest(TestCase):
         with self.assertRaises(ValidationError) as error:
             contest.save()
         self.assertEqual(error.exception.message, "Contest must not overlap another")
+
+    def test_active(self):
+        # create a few contests
+        contest1 = Contest()
+        contest1.start_promo = "2020-04-24"
+        contest1.start = "2020-05-01"
+        contest1.end = "2020-05-31"
+        contest1.save()
+
+        contest2 = Contest()
+        contest2.start_promo = "2020-06-21"
+        contest2.start = "2020-07-01"
+        contest2.end = "2020-07-31"
+        contest2.save()
+
+        def _assertEqual(create_obj, db_obj):
+            self.assertIsNotNone(db_obj)
+            self.assertEqual(str(create_obj.pk), db_obj.pk)
+
+        # before first promo starts, failure
+        with freeze_time("2020-04-01"):
+            self.assertIsNone(Contest.active())
+        self.assertIsNone(Contest.active(for_date=date(2020,4,1)))
+
+        # after promo starts for first contest
+        with freeze_time("2020-04-28"):
+            _assertEqual(contest1, Contest.active())
+
+        # during first contest
+        with freeze_time("2020-05-15"):
+            _assertEqual(contest1, Contest.active())
+
+        # after first contest, before promo starts for next
+        with freeze_time("2020-06-14"):
+            _assertEqual(contest1, Contest.active())
+
+        # after promo starts for next
+        with freeze_time("2020-06-28"):
+            _assertEqual(contest2, Contest.active())
+
+        # after last contest
+        with freeze_time("2020-08-14"):
+            _assertEqual(contest2, Contest.active())
+
+        # Now test the same using Contest.active with `for_date`
+        # instead of faking time
+        _assertEqual(contest1, Contest.active(for_date=date(2020,4,28)))
+        _assertEqual(contest1, Contest.active(for_date=date(2020,5,15)))
+        _assertEqual(contest1, Contest.active(for_date=date(2020,6,14)))
+        _assertEqual(contest2, Contest.active(for_date=date(2020,6,28)))
+        _assertEqual(contest2, Contest.active(for_date=date(2020,8,14)))
+
+    def test_associate_contest_with_account(self):
+        contest = Contest.objects.create(
+            start_promo="3000-04-24",
+            start="3000-05-01",
+            end="3000-05-31",
+        )
+        # TODO: use generator
+        acct = Account.objects.create(
+            email="fake@us.email",
+            age=100,
+        )
+        acct.contests.add(contest)
+        acct.contests.add(contest)
+        self.assertEqual(1, len(Contest.objects.all()))

--- a/home/tests/unit/test_contest.py
+++ b/home/tests/unit/test_contest.py
@@ -116,26 +116,32 @@ class TestContest(TestCase):
         # before first promo starts, failure
         with freeze_time("3000-04-01"):
             self.assertIsNone(Contest.active())
+            self.assertIsNone(Contest.active(strict=True))
 
         # after promo starts for first contest
         with freeze_time("3000-04-28"):
-            _assertEqual(contest1, Contest.active(for_date=date(3000,4,28)))
+            _assertEqual(contest1, Contest.active())
+            _assertEqual(contest1, Contest.active(strict=True))
 
         # during first contest
         with freeze_time("3000-05-15"):
             _assertEqual(contest1, Contest.active())
+            _assertEqual(contest1, Contest.active(strict=True))
 
         # after first contest, before promo starts for next
         with freeze_time("3000-06-14"):
             _assertEqual(contest1, Contest.active())
+            self.assertIsNone(Contest.active(strict=True))
 
         # after promo starts for next
         with freeze_time("3000-06-28"):
             _assertEqual(contest2, Contest.active())
+            _assertEqual(contest2, Contest.active(strict=True))
 
         # after last contest
         with freeze_time("3000-08-14"):
             _assertEqual(contest2, Contest.active())
+            self.assertIsNone(Contest.active(strict=True))
 
         # Now test the same using Contest.active with `for_date`
         # instead of faking time
@@ -147,7 +153,7 @@ class TestContest(TestCase):
         _assertEqual(contest2, Contest.active(for_date=date(3000,6,28)))
         _assertEqual(contest2, Contest.active(for_date=date(3000,8,14)))
 
-        # Test with `strict`
+        # Test with `for_date` and `strict`
         self.assertIsNone(Contest.active(for_date=date(3000,8,14), strict=True))
 
     def test_associate_contest_with_account(self):

--- a/home/views/api/dailywalk.py
+++ b/home/views/api/dailywalk.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from datetime import date
 from django.http import HttpResponseRedirect, JsonResponse
@@ -10,6 +11,8 @@ from django.core.exceptions import ObjectDoesNotExist
 from home.models import Contest, Device, Account, DailyWalk
 from .utils import validate_request_json
 
+
+logger = logging.getLogger(__name__)
 
 # Except from csrf validation
 @method_decorator(csrf_exempt, name="dispatch")
@@ -75,9 +78,9 @@ class DailyWalkCreateView(View):
                     device=device,
                 )
 
-            # Register contest for account
-            # Can be async
-            contest = Contest.active(for_date=date.fromisoformat(walk_date))
+            # Register contest for account if walk_date falls strictly within contest dates
+            # (Can be async)
+            contest = Contest.active(for_date=date.fromisoformat(walk_date), strict=True)
             if contest is not None:
                 try:
                     acct = device.account

--- a/home/views/api/dailywalk.py
+++ b/home/views/api/dailywalk.py
@@ -1,11 +1,13 @@
 import json
+
+from datetime import date
 from django.http import HttpResponseRedirect, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views import View, generic
 from django.utils.decorators import method_decorator
 from django.core.exceptions import ObjectDoesNotExist
 
-from home.models import Device, Account, DailyWalk
+from home.models import Contest, Device, Account, DailyWalk
 from .utils import validate_request_json
 
 

--- a/home/views/api/dailywalk.py
+++ b/home/views/api/dailywalk.py
@@ -83,7 +83,7 @@ class DailyWalkCreateView(View):
                     acct = device.account
                     acct.contests.add(contest)
                 except:
-                    pass
+                    logger.error("Could not add contest to account!", exc_info=True)
 
             # Update the json object
             json_response["payload"]["daily_walks"].append(

--- a/poetry.lock
+++ b/poetry.lock
@@ -177,7 +177,7 @@ pytz = "*"
 
 [[package]]
 name = "more-itertools"
-version = "8.10.0"
+version = "8.11.0"
 description = "More routines for operating on iterables, beyond itertools"
 category = "main"
 optional = false
@@ -207,7 +207,7 @@ dev = ["pre-commit", "tox"]
 
 [[package]]
 name = "psycopg2"
-version = "2.9.1"
+version = "2.9.2"
 description = "psycopg2 - Python-PostgreSQL Database Adapter"
 category = "main"
 optional = false
@@ -393,7 +393,7 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "8c2121df528363dfe1b13457fa6e3c9526def51991fb8ac6c2ce74a1abb9e9b3"
+content-hash = "47d8d23b622ed76c9e65dcc9f82e5ffb38a91c122b7ab476550732c11bde1227"
 
 [metadata.files]
 asgiref = [
@@ -509,8 +509,8 @@ libfaketime = [
     {file = "libfaketime-2.0.0.tar.gz", hash = "sha256:a63b3f359f6f15f7b814ebfe1e4a9642bd481178223f0d97aab1a537475876df"},
 ]
 more-itertools = [
-    {file = "more-itertools-8.10.0.tar.gz", hash = "sha256:1debcabeb1df793814859d64a81ad7cb10504c24349368ccf214c664c474f41f"},
-    {file = "more_itertools-8.10.0-py3-none-any.whl", hash = "sha256:56ddac45541718ba332db05f464bebfb0768110111affd27f66e0051f276fa43"},
+    {file = "more-itertools-8.11.0.tar.gz", hash = "sha256:0a2fd25d343c08d7e7212071820e7e7ea2f41d8fb45d6bc8a00cd6ce3b7aab88"},
+    {file = "more_itertools-8.11.0-py3-none-any.whl", hash = "sha256:88afff98d83d08fe5e4049b81e2b54c06ebb6b3871a600040865c7a592061cbb"},
 ]
 packaging = [
     {file = "packaging-21.2-py3-none-any.whl", hash = "sha256:14317396d1e8cdb122989b916fa2c7e9ca8e2be9e8060a6eff75b6b7b4d8a7e0"},
@@ -521,15 +521,17 @@ pluggy = [
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 psycopg2 = [
-    {file = "psycopg2-2.9.1-cp36-cp36m-win32.whl", hash = "sha256:7f91312f065df517187134cce8e395ab37f5b601a42446bdc0f0d51773621854"},
-    {file = "psycopg2-2.9.1-cp36-cp36m-win_amd64.whl", hash = "sha256:830c8e8dddab6b6716a4bf73a09910c7954a92f40cf1d1e702fb93c8a919cc56"},
-    {file = "psycopg2-2.9.1-cp37-cp37m-win32.whl", hash = "sha256:89409d369f4882c47f7ea20c42c5046879ce22c1e4ea20ef3b00a4dfc0a7f188"},
-    {file = "psycopg2-2.9.1-cp37-cp37m-win_amd64.whl", hash = "sha256:7640e1e4d72444ef012e275e7b53204d7fab341fb22bc76057ede22fe6860b25"},
-    {file = "psycopg2-2.9.1-cp38-cp38-win32.whl", hash = "sha256:079d97fc22de90da1d370c90583659a9f9a6ee4007355f5825e5f1c70dffc1fa"},
-    {file = "psycopg2-2.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:2c992196719fadda59f72d44603ee1a2fdcc67de097eea38d41c7ad9ad246e62"},
-    {file = "psycopg2-2.9.1-cp39-cp39-win32.whl", hash = "sha256:2087013c159a73e09713294a44d0c8008204d06326006b7f652bef5ace66eebb"},
-    {file = "psycopg2-2.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:bf35a25f1aaa8a3781195595577fcbb59934856ee46b4f252f56ad12b8043bcf"},
-    {file = "psycopg2-2.9.1.tar.gz", hash = "sha256:de5303a6f1d0a7a34b9d40e4d3bef684ccc44a49bbe3eb85e3c0bffb4a131b7c"},
+    {file = "psycopg2-2.9.2-cp310-cp310-win32.whl", hash = "sha256:6796ac614412ce374587147150e56d03b7845c9e031b88aacdcadc880e81bb38"},
+    {file = "psycopg2-2.9.2-cp310-cp310-win_amd64.whl", hash = "sha256:dfc32db6ce9ecc35a131320888b547199f79822b028934bb5b332f4169393e15"},
+    {file = "psycopg2-2.9.2-cp36-cp36m-win32.whl", hash = "sha256:77d09a79f9739b97099d2952bbbf18eaa4eaf825362387acbb9552ec1b3fa228"},
+    {file = "psycopg2-2.9.2-cp36-cp36m-win_amd64.whl", hash = "sha256:f65cba7924363e0d2f416041b48ff69d559548f2cb168ff972c54e09e1e64db8"},
+    {file = "psycopg2-2.9.2-cp37-cp37m-win32.whl", hash = "sha256:b8816c6410fa08d2a022e4e38d128bae97c1855e176a00493d6ec62ccd606d57"},
+    {file = "psycopg2-2.9.2-cp37-cp37m-win_amd64.whl", hash = "sha256:26322c3f114de1f60c1b0febf8fdd595c221b4f624524178f515d07350a71bd1"},
+    {file = "psycopg2-2.9.2-cp38-cp38-win32.whl", hash = "sha256:77b9105ef37bc005b8ffbcb1ed6d8685bb0e8ce84773738aa56421a007ec5a7a"},
+    {file = "psycopg2-2.9.2-cp38-cp38-win_amd64.whl", hash = "sha256:91c7fd0fe9e6c118e8ff5b665bc3445781d3615fa78e131d0b4f8c85e8ca9ec8"},
+    {file = "psycopg2-2.9.2-cp39-cp39-win32.whl", hash = "sha256:a761b60da0ecaf6a9866985bcde26327883ac3cdb90535ab68b8d784f02b05ef"},
+    {file = "psycopg2-2.9.2-cp39-cp39-win_amd64.whl", hash = "sha256:fd7ddab7d6afee4e21c03c648c8b667b197104713e57ec404d5b74097af21e31"},
+    {file = "psycopg2-2.9.2.tar.gz", hash = "sha256:a84da9fa891848e0270e8e04dcca073bc9046441eeb47069f5c0e36783debbea"},
 ]
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -131,6 +131,17 @@ python-dateutil = ">=2.4"
 text-unidecode = "1.3"
 
 [[package]]
+name = "freezegun"
+version = "1.1.0"
+description = "Let your Python tests travel through time"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+python-dateutil = ">=2.7"
+
+[[package]]
 name = "gunicorn"
 version = "20.1.0"
 description = "WSGI HTTP Server for UNIX"
@@ -382,7 +393,7 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "06bac3d6dfded2481107bea7d9bb144b1a01f915df4263087a3d5e009b4b37b8"
+content-hash = "8c2121df528363dfe1b13457fa6e3c9526def51991fb8ac6c2ce74a1abb9e9b3"
 
 [metadata.files]
 asgiref = [
@@ -481,6 +492,10 @@ docopt = [
 faker = [
     {file = "Faker-8.16.0-py3-none-any.whl", hash = "sha256:bb10913b9d3ac2aa37180f816c82040e81f9e0c32cb08445533f293cec8930bf"},
     {file = "Faker-8.16.0.tar.gz", hash = "sha256:d70b375d0af0e4c3abd594003691a1055a96281a414884e623d27bccc7d781da"},
+]
+freezegun = [
+    {file = "freezegun-1.1.0-py2.py3-none-any.whl", hash = "sha256:2ae695f7eb96c62529f03a038461afe3c692db3465e215355e1bb4b0ab408712"},
+    {file = "freezegun-1.1.0.tar.gz", hash = "sha256:177f9dd59861d871e27a484c3332f35a6e3f5d14626f2bf91be37891f18927f3"},
 ]
 gunicorn = [
     {file = "gunicorn-20.1.0-py3-none-any.whl", hash = "sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ uuid = "^1.30"
 faker = "^8.11.0"
 
 [tool.poetry.dev-dependencies]
+freezegun = "^1.1.0"
 pytest = "^5.4"
 libfaketime = "^2.0.0"
 pytest-libfaketime = "^0.1.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,10 +12,10 @@ docopt==0.6.2
 faker==8.16.0; python_version >= "3.6"
 gunicorn==20.1.0; python_version >= "3.5"
 idna==3.3; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.5"
-more-itertools==8.10.0; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.5"
+more-itertools==8.11.0; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.5"
 packaging==21.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 pluggy==0.13.1; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.5"
-psycopg2==2.9.1; python_version >= "3.6"
+psycopg2==2.9.2; python_version >= "3.6"
 py==1.11.0; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5"
 pyparsing==2.4.7; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 pytest-django==3.10.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")


### PR DESCRIPTION
## Summary
Fixes broken test `test_contest_current` in `home/tests/integration/contest/test_current.py`, which was being skipped because of failures.

Also adds unit test for `Contest.active` to supplement integration test.

## Changes
* Imports freezegun
* Updates integration test `test_contest_current` to use freezegun instead of libfaketime
* Adds unit test `test_active` in home/tests/unit/test_contest.py
* **Updates dailywalk API such that when a daily walk is added, the active contest is looked up and added to the associated Account**

## Deploying
No migrations.
Safe to revert.
