### PR TITLE
Management functions to reset db and backfill account contests

### DIFF
--- a/example.env
+++ b/example.env
@@ -3,3 +3,4 @@ DATABASE_URL=postgresql://postgres@db/iwalk
 DEBUG=1
 SECRET_KEY=q!=ahgtraat*k4ytuniq)0892h7j5^2koqp55mh6p18$4344ks
 TIME_ZONE=America/Los_Angeles
+DEPLOY_ENV=development

--- a/home/management/commands/backfill.py
+++ b/home/management/commands/backfill.py
@@ -1,0 +1,91 @@
+import csv
+
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+from home.models import Contest, DailyWalk
+
+
+class Command(BaseCommand):
+    """
+    Example:
+        python manage.py backfill account_contests --dry_run
+    """
+
+    help = "Backfill data"
+    choices = {
+        "account_contests": "Use dailywalks to backfill account_contests relationship (many-to-many)",
+    }
+
+    def add_arguments(self, parser):
+        subparsers = parser.add_subparsers()
+
+        # Backfill table home_account_contests (contests by account)
+        subparser_account_contests = subparsers.add_parser(
+            "account_contests",
+            help="Use dailywalks to backfill account_contests relationship (many-to-many)",
+        )
+        subparser_account_contests.add_argument(
+            "--dry_run", "-N", action="store_true", help="Dry run (no-op)"
+        )
+        subparser_account_contests.set_defaults(func=self._backfill_account_contests)
+
+        subparser_account_contests_opts = (
+            subparser_account_contests.add_mutually_exclusive_group(required=True)
+        )
+        subparser_account_contests_opts.add_argument(
+            "--all", help="Populate all contests"
+        )
+        subparser_account_contests_opts.add_argument(
+            "--contest_date",
+            help="Select contest to populate by any date during the contest (or multiple if separated by commas)",
+        )
+        subparser_account_contests_opts.add_argument(
+            "--contest_id", help="Select contest to populate by contest_id"
+        )
+
+    def handle(self, *args, **options):
+        options["func"](**options)
+
+    def _backfill_account_contests(self, dry_run=False, **options):
+        walks_processed = 0
+        contest_walks = 0
+        entry_set = set()
+
+        # Choose contest
+        # TODO: allow start and end dates for filtering
+        if options["contest_id"]:
+            contests = set(Contest.objects.get(pk=options["contest_id"]))
+        elif options["contest_date"]:
+            contests = set([
+                Contest.active(for_date=_date, strict=True)
+                for _date in options["contest_date"].split(",")
+            ])
+        else:
+            contests = Contest.objects.all()
+
+        # Retrieve ALL daily walks and try to fit them into contests
+        daily_walks = DailyWalk.objects.all().order_by("date")
+        for walk in daily_walks:
+            acct = walk.account
+            walks_processed += 1
+
+            # Retrieve the active contest for this walk
+            active_contest = Contest.active(for_date=walk.date, strict=True)
+
+            # Only process if the active contest was selected
+            if active_contest in contests:
+                contest_walks += 1
+
+                if not acct.contests.filter(pk=active_contest.pk):
+                    # Keep track of rows that were (or would have been) added
+                    entry_set.add((acct, active_contest))
+                    if not dry_run:
+                        walk.account.contests.add(active_contest)
+
+            if walks_processed % 1000 == 0:
+                print(f"Processed {walks_processed} walks...")
+
+        if_dry_run = " (DRY RUN)" if dry_run else ""
+        print(f"Contest walks processed: {contest_walks}")
+        print(f"Rows added: {len(entry_set)}{if_dry_run}")

--- a/home/management/commands/resetdb.py
+++ b/home/management/commands/resetdb.py
@@ -1,0 +1,24 @@
+import csv
+
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+
+class Command(BaseCommand):
+    help = "Reset database (truncate application tables)"
+
+    def handle(self, *args, **options):
+        question = "\nAre you sure you want to truncate all tables? (Type `yes` exactly): "
+        answer = input(question)
+        if answer == "yes":
+            cursor = connection.cursor()
+
+            # Truncating accounts (with cascade) will also truncate
+            # devices, daily walks, and intentional walks
+            cursor.execute("TRUNCATE TABLE home_account RESTART IDENTITY CASCADE;")
+            print("All accounts, devices, and walks have been reset.")
+
+            # TODO: Also reset contests?
+
+        else:
+            print("Aborted resetdb.\n")

--- a/home/management/commands/resetdb.py
+++ b/home/management/commands/resetdb.py
@@ -14,7 +14,9 @@ class Command(BaseCommand):
             print("This command is not allowed on a production server.")
             sys.exit(1)
 
-        question = "\nAre you sure you want to truncate all tables? (Type `yes` exactly): "
+        question = (
+            "\nAre you sure you want to truncate all tables? (Type `yes` exactly): "
+        )
         answer = input(question)
         if answer == "yes":
             cursor = connection.cursor()

--- a/home/management/commands/resetdb.py
+++ b/home/management/commands/resetdb.py
@@ -1,4 +1,6 @@
 import csv
+import os
+import sys
 
 from django.core.management.base import BaseCommand
 from django.db import connection
@@ -8,6 +10,10 @@ class Command(BaseCommand):
     help = "Reset database (truncate application tables)"
 
     def handle(self, *args, **options):
+        if os.getenv("DEPLOY_ENV").lower().startswith("prod"):
+            print("This command is not allowed on a production server.")
+            sys.exit(1)
+
         question = "\nAre you sure you want to truncate all tables? (Type `yes` exactly): "
         answer = input(question)
         if answer == "yes":
@@ -18,7 +24,9 @@ class Command(BaseCommand):
             cursor.execute("TRUNCATE TABLE home_account RESTART IDENTITY CASCADE;")
             print("All accounts, devices, and walks have been reset.")
 
-            # TODO: Also reset contests?
+            # Also truncate contests
+            cursor.execute("TRUNCATE TABLE home_contest CASCADE;")
+            print("All contests have been reset.")
 
         else:
             print("Aborted resetdb.\n")


### PR DESCRIPTION
## Summary
Adds a management function for resetting the DB to a clean state. I would say this actually does not increase our risk exposure because in order to run the command, you would need to have the same privileges and access required for destructive actions executed through `dbshell`. I have also added a manual confirmation step so that it would occur by fat-fingering.

Also adds a management function that backfills the `contests` field of `Account` by iterating through all daily walks, finding the relevant contest, and adding it to the account associated with the walk. This could be replaced by a formal sql migration, but I wanted it to be a command line function where the specific contest id or dates could be specified, which would not be possible with a migration.

## Changes
Adds two management scripts

#### resetdb
```
python manage.py resetdb
```

#### backfill
```
python manage.py backfill account_contest --all
OR
python manage.py backfill account_contest --contest_id <CONTEST_ID>
OR
python manage.py backfill account_contest --contest_date <CONTEST_DATE>
```

## Deploying
Does not affect servers until scripts are run.
Safe to revert.