### PR TITLE
Processing new registration flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ server container to perform the following actions.
    ```
    $ docker-compose exec server bash -l
    ```
+   If missing module, re-build the server container
 
  * To stop all the containers, in case things didn't shutdown properly with CTRL-C:
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 ## Server management commands
 
 Note: see the instructions in the next quick reference section to start/log in to a running
-server container to perform the following actions.
+server container and perform the following actions within the container CLI.
 
  * To create an admin user that can log in to the web views:
 

--- a/home/tests/integration/appuser/test_create.py
+++ b/home/tests/integration/appuser/test_create.py
@@ -16,11 +16,6 @@ class ApiTestCase(TestCase):
             "zip": "72185",
             "age": 99,
             "account_id": "12345",
-            "is_latino": False,
-            "gender": "TM",
-            "gender_other": None,
-            "race": ["BL", "OT"],
-            "race_other": "Some other race",
         }
         # Content type
         self.content_type = "application/json"
@@ -44,9 +39,8 @@ class ApiTestCase(TestCase):
             response_data["payload"]["account_id"], self.request_params["account_id"], msg=fail_message,
         )
         user_obj = Account.objects.get(email=self.request_params["email"])
-        for field in ["name", "email", "zip", "age", "is_latino", "gender", "gender_other", "race_other"]:
-            self.assertEqual(getattr(user_obj, field), self.request_params[field], msg=fail_message)
-        self.assertSetEqual(user_obj.race, set(self.request_params["race"]), msg=fail_message)
+        for field in ["name", "email", "zip", "age"]:
+            self.assertEqual(getattr(user_obj, field), self.request_params[field], msg=f"{field}")
 
     # Test creation of a duplicate user
     # This should default to an update
@@ -67,9 +61,8 @@ class ApiTestCase(TestCase):
             response_data["payload"]["account_id"], self.request_params["account_id"], msg=fail_message,
         )
         user_obj = Account.objects.get(email=self.request_params["email"])
-        for field in ["name", "email", "zip", "age", "is_latino", "gender", "gender_other", "race_other"]:
-            self.assertEqual(getattr(user_obj, field), self.request_params[field], msg=fail_message)
-        self.assertSetEqual(user_obj.race, set(self.request_params["race"]), msg=fail_message)
+        for field in ["name", "email", "zip", "age"]:
+            self.assertEqual(getattr(user_obj, field), self.request_params[field], msg=f"{field}")
 
 
         # Create the same user again
@@ -86,9 +79,8 @@ class ApiTestCase(TestCase):
             response_data["payload"]["account_id"], self.request_params["account_id"], msg=fail_message,
         )
         user_obj = Account.objects.get(email=self.request_params["email"])
-        for field in ["name", "email", "zip", "age", "is_latino", "gender", "gender_other", "race_other"]:
-            self.assertEqual(getattr(user_obj, field), self.request_params[field], msg=fail_message)
-        self.assertSetEqual(user_obj.race, set(self.request_params["race"]), msg=fail_message)
+        for field in ["name", "email", "zip", "age"]:
+            self.assertEqual(getattr(user_obj, field), self.request_params[field], msg=f"{field}")
 
     # Test creation of the same user using a different device
     # This should create a new account with the same email
@@ -109,9 +101,8 @@ class ApiTestCase(TestCase):
             response_data["payload"]["account_id"], self.request_params["account_id"], msg=fail_message,
         )
         user_obj = Account.objects.get(email=self.request_params["email"])
-        for field in ["name", "email", "zip", "age", "is_latino", "gender", "gender_other", "race_other"]:
-            self.assertEqual(getattr(user_obj, field), self.request_params[field], msg=fail_message)
-        self.assertSetEqual(user_obj.race, set(self.request_params["race"]), msg=fail_message)
+        for field in ["name", "email", "zip", "age"]:
+            self.assertEqual(getattr(user_obj, field), self.request_params[field], msg=f"{field}")
 
         # Create the same user but with a different account id
         # This should create a new user
@@ -130,9 +121,8 @@ class ApiTestCase(TestCase):
             response_data["payload"]["account_id"], self.request_params["account_id"], msg=fail_message,
         )
         user_obj = Account.objects.get(email=self.request_params["email"])
-        for field in ["name", "email", "zip", "age", "is_latino", "gender", "gender_other", "race_other"]:
+        for field in ["name", "email", "zip", "age"]:
             self.assertEqual(getattr(user_obj, field), self.request_params[field], msg=fail_message)
-        self.assertSetEqual(user_obj.race, set(self.request_params["race"]), msg=fail_message)
 
     # Test failure while create a new app with missing information
     def test_create_appuser_failure_missing_field_age(self):
@@ -169,3 +159,10 @@ class ApiTestCase(TestCase):
         self.assertEqual(
             response_data["message"], "Required input 'account_id' missing in the request", msg=fail_message,
         )
+
+    # TODO: Test update of user with other demographics (PUT)
+            # "is_latino": False,
+            # "gender": "TM",
+            # "gender_other": None,
+            # "race": ["BL", "OT"],
+            # "race_other": "Some other race",

--- a/home/tests/integration/appuser/test_create.py
+++ b/home/tests/integration/appuser/test_create.py
@@ -106,10 +106,10 @@ class ApiTestCase(TestCase):
 
         # Create the same user but with a different account id
         # This should create a new user
-        self.request_params["account_id"] = "54321"
+        request_params = {**self.request_params, "account_id": "54321"}
 
         # Register the user first
-        response = self.client.post(path=self.url, data=self.request_params, content_type=self.content_type)
+        response = self.client.post(path=self.url, data=request_params, content_type=self.content_type)
         # Check for a successful response by the server
         self.assertEqual(response.status_code, 200)
         # Parse the response
@@ -118,20 +118,21 @@ class ApiTestCase(TestCase):
         self.assertEqual(response_data["status"], "success", msg=fail_message)
         self.assertEqual(response_data["message"], "Device registered & account updated successfully", msg=fail_message)
         self.assertEqual(
-            response_data["payload"]["account_id"], self.request_params["account_id"], msg=fail_message,
+            response_data["payload"]["account_id"], request_params["account_id"], msg=fail_message,
         )
-        user_obj = Account.objects.get(email=self.request_params["email"])
+        user_obj = Account.objects.get(email=request_params["email"])
         for field in ["name", "email", "zip", "age"]:
-            self.assertEqual(getattr(user_obj, field), self.request_params[field], msg=fail_message)
+            self.assertEqual(getattr(user_obj, field), request_params[field], msg=fail_message)
 
     # Test failure while create a new app with missing information
     def test_create_appuser_failure_missing_field_age(self):
         # Required fields for user creation
         # Remove the age field
-        del self.request_params["age"]
+        request_params = self.request_params.copy()
+        del request_params["age"]
 
         # Register the user
-        response = self.client.post(path=self.url, data=self.request_params, content_type=self.content_type)
+        response = self.client.post(path=self.url, data=request_params, content_type=self.content_type)
         # Check for a successful response by the server
         self.assertEqual(response.status_code, 200)
         # Parse the response
@@ -146,10 +147,11 @@ class ApiTestCase(TestCase):
     def test_create_appuser_failure_missing_field_device_id(self):
         # Required fields for user creation
         # Remove the account_id field
-        del self.request_params["account_id"]
+        request_params = self.request_params.copy()
+        del request_params["account_id"]
 
         # Register the user
-        response = self.client.post(path=self.url, data=self.request_params, content_type=self.content_type)
+        response = self.client.post(path=self.url, data=request_params, content_type=self.content_type)
         # Check for a successful response by the server
         self.assertEqual(response.status_code, 200)
         # Parse the response
@@ -159,10 +161,3 @@ class ApiTestCase(TestCase):
         self.assertEqual(
             response_data["message"], "Required input 'account_id' missing in the request", msg=fail_message,
         )
-
-    # TODO: Test update of user with other demographics (PUT)
-            # "is_latino": False,
-            # "gender": "TM",
-            # "gender_other": None,
-            # "race": ["BL", "OT"],
-            # "race_other": "Some other race",

--- a/home/tests/integration/appuser/test_update.py
+++ b/home/tests/integration/appuser/test_update.py
@@ -81,8 +81,7 @@ class ApiTestCase(TestCase):
     # This would hit the same creation URL
     def test_update_appuser_age(self):
         # UPDATE THE USERS AGE
-        request_params = self.request_params
-        request_params["age"] = 88
+        request_params = {**self.request_params, "age": 88}
 
         # Send the update
         response = self.client.post(path=self.url, data=request_params, content_type=self.content_type)
@@ -104,8 +103,7 @@ class ApiTestCase(TestCase):
     # This would hit the same creation URL
     def test_update_appuser_name(self):
         # UPDATE THE USERS NAME
-        request_params = self.request_params
-        request_params["name"] = "Abhay"
+        request_params = {**self.request_params, "name": "Abhay"}
 
         # Send the update
         response = self.client.post(path=self.url, data=request_params, content_type=self.content_type)
@@ -127,8 +125,7 @@ class ApiTestCase(TestCase):
     # This shouldn't update
     def test_update_appuser_email(self):
         # UPDATE THE USERS EMAIL
-        request_params = self.request_params
-        request_params["email"] = "abhaykashyap@blah.com"
+        request_params = {**self.request_params, "email": "abhaykashyap@blah.com"}
 
         # Register the user first
         response = self.client.post(path=self.url, data=request_params, content_type=self.content_type)

--- a/home/tests/integration/appuser/test_update.py
+++ b/home/tests/integration/appuser/test_update.py
@@ -9,13 +9,16 @@ class ApiTestCase(TestCase):
         self.client = Client()
         # Url for creation
         self.url = "/api/appuser/create"
+        # Constants
+        self.account_id = "12345"
+        self.email = "john@blah.com"
         # Request parameters
         self.request_params = {
             "name": "John Doe",
-            "email": "john@blah.com",
+            "email": self.email,
             "zip": "72185",
             "age": 99,
-            "account_id": "12345",
+            "account_id": self.account_id,
         }
         # Content type
         self.content_type = "application/json"
@@ -30,22 +33,19 @@ class ApiTestCase(TestCase):
         fail_message = f"Server response - {response_data}"
         self.assertEqual(response_data["status"], "success", msg=fail_message)
 
-    # Test updating a User's demographics 
+    # Test updating a User's demographics
     # First user screen (name, email, age) registers a user
-    # Additional demographics update with PUT. Test applies to these changes. 
+    # Additional demographics update with PUT. Test applies to these changes.
     def test_update_appuser_demographics(self):
-    
-        # UPDATE USER DEMOGRAPHICS 
-        self.request_params.update({
+
+        # UPDATE USER DEMOGRAPHICS
+        request_params = {
+            "account_id": self.account_id,
             "is_latino": False,
-            "gender": "TM",
-            "gender_other": None,
-            "race": ["BL", "OT"],
-            "race_other": "Some other race",
-        })
+        }
 
         # Register the user
-        response = self.client.post(path=self.url, data=self.request_params, content_type=self.content_type)
+        response = self.client.put(path=self.url, data=request_params, content_type=self.content_type)
 
         # Check for a successful response by the server
         self.assertEqual(response.status_code, 200)
@@ -53,23 +53,39 @@ class ApiTestCase(TestCase):
         response_data = response.json()
         fail_message = f"Server response - {response_data}"
         self.assertEqual(response_data["status"], "success", msg=fail_message)
-        self.assertEqual(response_data["message"], "Device & account updated successfully", msg=fail_message)
-        self.assertEqual(
-            response_data["payload"]["account_id"], self.request_params["account_id"], msg=fail_message,
-        )
-        user_obj = Account.objects.get(email=self.request_params["email"])
-        for field in ["is_latino", "gender", "gender_other", "race_other"]:  
-            self.assertEqual(getattr(user_obj, field), self.request_params[field], msg=fail_message)
-        self.assertSetEqual(user_obj.race, set(self.request_params["race"]), msg=fail_message)
+        self.assertEqual(response_data["message"], "Account updated successfully", msg=fail_message)
+        user_obj = Account.objects.get(email=self.email)
+
+        field = "is_latino"
+        self.assertEqual(getattr(user_obj, field), request_params[field], msg=fail_message)
+
+        request_params = {
+            "account_id": self.account_id,
+            "gender": "TM",
+            "gender_other": None,
+            "race": ["BL", "OT"],
+            "race_other": "Some other race",
+        }
+
+        response = self.client.put(path=self.url, data=request_params, content_type=self.content_type)
+        self.assertEqual(response.status_code, 200)
+        user_obj = Account.objects.get(email=self.email)
+
+        for field in ["gender", "gender_other", "race_other"]:
+            self.assertEqual(getattr(user_obj, field), request_params[field], msg=fail_message)
+        self.assertSetEqual(user_obj.race, set(request_params["race"]), msg=fail_message)
+
+
 
     # Test updating a User's age
     # This would hit the same creation URL
     def test_update_appuser_age(self):
         # UPDATE THE USERS AGE
-        self.request_params["age"] = 88
+        request_params = self.request_params
+        request_params["age"] = 88
 
         # Send the update
-        response = self.client.post(path=self.url, data=self.request_params, content_type=self.content_type)
+        response = self.client.post(path=self.url, data=request_params, content_type=self.content_type)
         # Check for a successful response by the server
         self.assertEqual(response.status_code, 200)
         # Parse the response
@@ -78,20 +94,21 @@ class ApiTestCase(TestCase):
         self.assertEqual(response_data["status"], "success", msg=fail_message)
         self.assertEqual(response_data["message"], "Device & account updated successfully", msg=fail_message)
         self.assertEqual(
-            response_data["payload"]["account_id"], self.request_params["account_id"], msg=fail_message,
+            response_data["payload"]["account_id"], request_params["account_id"], msg=fail_message,
         )
-        user_obj = Account.objects.get(email=self.request_params["email"])
+        user_obj = Account.objects.get(email=self.email)
         for field in ["name", "email", "zip", "age"]:
-            self.assertEqual(getattr(user_obj, field), self.request_params[field], msg=fail_message)
+            self.assertEqual(getattr(user_obj, field), request_params[field], msg=fail_message)
 
     # Test updating a User's name
     # This would hit the same creation URL
     def test_update_appuser_name(self):
         # UPDATE THE USERS NAME
-        self.request_params["name"] = "Abhay"
+        request_params = self.request_params
+        request_params["name"] = "Abhay"
 
         # Send the update
-        response = self.client.post(path=self.url, data=self.request_params, content_type=self.content_type)
+        response = self.client.post(path=self.url, data=request_params, content_type=self.content_type)
         # Check for a successful response by the server
         self.assertEqual(response.status_code, 200)
         # Parse the response
@@ -100,20 +117,21 @@ class ApiTestCase(TestCase):
         self.assertEqual(response_data["status"], "success", msg=fail_message)
         self.assertEqual(response_data["message"], "Device & account updated successfully", msg=fail_message)
         self.assertEqual(
-            response_data["payload"]["account_id"], self.request_params["account_id"], msg=fail_message,
+            response_data["payload"]["account_id"], request_params["account_id"], msg=fail_message,
         )
-        user_obj = Account.objects.get(email=self.request_params["email"])
+        user_obj = Account.objects.get(email=self.email)
         for field in ["name", "email", "zip", "age"]:
-            self.assertEqual(getattr(user_obj, field), self.request_params[field], msg=fail_message)
+            self.assertEqual(getattr(user_obj, field), request_params[field], msg=fail_message)
 
     # Test updating a User's email
     # This shouldn't update
     def test_update_appuser_email(self):
         # UPDATE THE USERS EMAIL
-        self.request_params["email"] = "abhaykashyap@blah.com"
+        request_params = self.request_params
+        request_params["email"] = "abhaykashyap@blah.com"
 
         # Register the user first
-        response = self.client.post(path=self.url, data=self.request_params, content_type=self.content_type)
+        response = self.client.post(path=self.url, data=request_params, content_type=self.content_type)
         # Check for a successful response by the server
         self.assertEqual(response.status_code, 200)
         # Parse the response

--- a/home/tests/integration/appuser/test_update.py
+++ b/home/tests/integration/appuser/test_update.py
@@ -35,10 +35,7 @@ class ApiTestCase(TestCase):
     # Additional demographics update with PUT. Test applies to these changes. 
     def test_update_appuser_demographics(self):
     
-        # Register the user
-        response = self.client.post(path=self.url, data=self.request_params, content_type=self.content_type)
-
-        # Update user's demographics 
+        # UPDATE USER DEMOGRAPHICS 
         self.request_params.update({
             "is_latino": False,
             "gender": "TM",
@@ -47,16 +44,21 @@ class ApiTestCase(TestCase):
             "race_other": "Some other race",
         })
 
+        # Register the user
+        response = self.client.post(path=self.url, data=self.request_params, content_type=self.content_type)
+
         # Check for a successful response by the server
         self.assertEqual(response.status_code, 200)
         # Parse the response
         response_data = response.json()
         fail_message = f"Server response - {response_data}"
-        self.assertEqual(response_data["status"], "error", msg=fail_message)
+        self.assertEqual(response_data["status"], "success", msg=fail_message)
         self.assertEqual(response_data["message"], "Device & account updated successfully", msg=fail_message)
-
+        self.assertEqual(
+            response_data["payload"]["account_id"], self.request_params["account_id"], msg=fail_message,
+        )
         user_obj = Account.objects.get(email=self.request_params["email"])
-        for field in ["is_latino", "gender", "gender_other", "race_other"]:
+        for field in ["is_latino", "gender", "gender_other", "race_other"]:  
             self.assertEqual(getattr(user_obj, field), self.request_params[field], msg=fail_message)
         self.assertSetEqual(user_obj.race, set(self.request_params["race"]), msg=fail_message)
 
@@ -79,9 +81,8 @@ class ApiTestCase(TestCase):
             response_data["payload"]["account_id"], self.request_params["account_id"], msg=fail_message,
         )
         user_obj = Account.objects.get(email=self.request_params["email"])
-        for field in ["name", "email", "zip", "age", "is_latino", "gender", "gender_other", "race_other"]:
+        for field in ["name", "email", "zip", "age"]:
             self.assertEqual(getattr(user_obj, field), self.request_params[field], msg=fail_message)
-        self.assertSetEqual(user_obj.race, set(self.request_params["race"]), msg=fail_message)
 
     # Test updating a User's name
     # This would hit the same creation URL
@@ -102,9 +103,8 @@ class ApiTestCase(TestCase):
             response_data["payload"]["account_id"], self.request_params["account_id"], msg=fail_message,
         )
         user_obj = Account.objects.get(email=self.request_params["email"])
-        for field in ["name", "email", "zip", "age", "is_latino", "gender", "gender_other", "race_other"]:
+        for field in ["name", "email", "zip", "age"]:
             self.assertEqual(getattr(user_obj, field), self.request_params[field], msg=fail_message)
-        self.assertSetEqual(user_obj.race, set(self.request_params["race"]), msg=fail_message)
 
     # Test updating a User's email
     # This shouldn't update

--- a/home/views/api/appuser.py
+++ b/home/views/api/appuser.py
@@ -61,26 +61,30 @@ def validate_account_input(data: dict):
 def update_account(acct: Account, data: dict):
     # Data fields vary based on registration screen
 
-    # Screen 1: Name, Email, Zip, Age. 
-    # Does not update email
-    if data["email"] is not None:
+    # Screen 1: Name, Email, Zip, Age.
+    # Not possible to update email
+    if data.get("name") is not None:
         acct.name = data["name"]
-        acct.zip = data["zip"]
-        acct.age = data["age"]
-        acct.is_sf_resident = data["zip"] in SAN_FRANCISCO_ZIP_CODES
         acct.is_tester = is_tester(data["name"])
-    
+
+    if data.get("zip") is not None:
+        acct.zip = data["zip"]
+        acct.is_sf_resident = data["zip"] in SAN_FRANCISCO_ZIP_CODES
+
+    if data.get("age") is not None:
+        acct.age = data["age"]
+
     # Screen 2. Latino/Hispanic Origin
     if data.get("is_latino") is not None:
         acct.is_latino = data.get("is_latino")
-    
+
     # Screen 3. Race
     if data.get("race") is not None:
         acct.race = data.get("race", [])
         acct.race_other = data.get("race_other")
-    
+
     # Screen 4. Gender Identity
-    if data.get("gender") is not None:  
+    if data.get("gender") is not None:
         acct.gender = data.get("gender")
         acct.gender_other = data.get("gender_other")
     acct.save()
@@ -101,7 +105,7 @@ class AppUserCreateView(View):
         json_status = validate_request_json(json_data, required_fields=["account_id"])
         if "status" in json_status and json_status["status"] == "error":
             return JsonResponse(json_status)
-        
+
         # Update user attributes.
         device = Device.objects.get(device_id=json_data["account_id"])
         account = Account.objects.get(email=device.account.email)

--- a/home/views/api/appuser.py
+++ b/home/views/api/appuser.py
@@ -59,17 +59,30 @@ def validate_account_input(data: dict):
         assert False, "'gender_other' should not be specified without 'gender'"
 
 def update_account(acct: Account, data: dict):
+    # Data fields vary based on registration screen
+
+    # Screen 1: Name, Email, Zip, Age. 
     # Does not update email
-    acct.name = data["name"]
-    acct.zip = data["zip"]
-    acct.age = data["age"]
-    acct.is_sf_resident = data["zip"] in SAN_FRANCISCO_ZIP_CODES
-    acct.is_tester = is_tester(data["name"])
-    acct.is_latino = data.get("is_latino")
-    acct.race = data.get("race", [])
-    acct.race_other = data.get("race_other")
-    acct.gender = data.get("gender")
-    acct.gender_other = data.get("gender_other")
+    if data["email"] is not None:
+        acct.name = data["name"]
+        acct.zip = data["zip"]
+        acct.age = data["age"]
+        acct.is_sf_resident = data["zip"] in SAN_FRANCISCO_ZIP_CODES
+        acct.is_tester = is_tester(data["name"])
+    
+    # Screen 2. Latino/Hispanic Origin
+    if data.get("is_latino") is not None:
+        acct.is_latino = data.get("is_latino")
+    
+    # Screen 3. Race
+    if data.get("race") is not None:
+        acct.race = data.get("race", [])
+        acct.race_other = data.get("race_other")
+    
+    # Screen 4. Gender Identity
+    if data.get("gender") is not None:  
+        acct.gender = data.get("gender")
+        acct.gender_other = data.get("gender_other")
     acct.save()
 
 # Except from csrf validation
@@ -79,7 +92,29 @@ class AppUserCreateView(View):
     If already present, the same endpoint will update user details except email.
     """
 
-    http_method_names = ["post"]
+    http_method_names = ["post", "put"]
+
+    def put(self, request, *args, **kwargs):
+        json_data = json.loads(request.body)
+
+        # Validate json. If account_id is missing, send back the response message
+        json_status = validate_request_json(json_data, required_fields=["account_id"])
+        if "status" in json_status and json_status["status"] == "error":
+            return JsonResponse(json_status)
+        
+        # Update user attributes.
+        device = Device.objects.get(device_id=json_data["account_id"])
+        account = Account.objects.get(email=device.account.email)
+        update_account(account, json_data)
+        message = "Account updated successfully"
+
+        return JsonResponse(
+            {
+                "status": "success",
+                "message": message,
+            }
+        )
+
 
     def post(self, request, *args, **kwargs):
         # Parse the body json
@@ -98,6 +133,7 @@ class AppUserCreateView(View):
         # must be created to separate data. Otherwise, attribution will be to the account
         # email created first.
 
+        # For a participating device
         try:
             # NOTE: Account id here maps to a device id. Perhaps the API definition could
             # be changed in the future
@@ -108,16 +144,17 @@ class AppUserCreateView(View):
                 return JsonResponse({"status": "error", "message": "Email cannot be updated. Contact admin"})
 
             # Otherwise, update the account's other details
-            update_account(device.account, json_data)
-            message = "Device & account updated successfully"
+            account = Account.objects.get(email=json_data["email"])
+            update_account(account, json_data)
+            message = "Device & Account updated successfully"
 
         # This implies that it is a new device
         except ObjectDoesNotExist:
             # Check if the user account exists. If not, create it
-            account_updated = False
             try:
                 account = Account.objects.get(email=json_data["email"])
                 update_account(account, json_data)
+                message = "Account updated successfully"
                 account_updated = True
             except ObjectDoesNotExist:
                 # Partially create account first, with required fields
@@ -127,7 +164,6 @@ class AppUserCreateView(View):
                     zip=json_data["zip"],
                     age=json_data["age"],
                 )
-                update_account(account, json_data)
 
             # Create a new device object and link it to the account
             device = Device.objects.create(device_id=json_data["account_id"], account=account)

--- a/home/views/api/appuser.py
+++ b/home/views/api/appuser.py
@@ -146,7 +146,7 @@ class AppUserCreateView(View):
             # Otherwise, update the account's other details
             account = Account.objects.get(email=json_data["email"])
             update_account(account, json_data)
-            message = "Device & Account updated successfully"
+            message = "Device & account updated successfully"
 
         # This implies that it is a new device
         except ObjectDoesNotExist:
@@ -164,6 +164,8 @@ class AppUserCreateView(View):
                     zip=json_data["zip"],
                     age=json_data["age"],
                 )
+                account_updated = False
+
 
             # Create a new device object and link it to the account
             device = Device.objects.create(device_id=json_data["account_id"], account=account)


### PR DESCRIPTION
# Summary
The IW app will be splitting the registration process into a number of steps. At each step, the user will enter information and press "Next", which will trigger an API call with partial registration data.

# Changes
* This PR modifies AppUserCreateView to allow first a POST request with just name, email, zip, and age and returns account_id. 
* Each subsequent PUT request will now be an account update that requires account_id along with any additional fields. 
* Revises integration tests in test_create, to limit fields to name, email, zip, and age. 
* Revises test_update to echo these changes
* Adds test_update_appuser_demographics to test_update to process ethnicity, gender, and race

# Reverting
* Safe to revert