### PR TITLE
fix: correct heatmap labels

### DIFF
--- a/home/templates/home/user_list.html
+++ b/home/templates/home/user_list.html
@@ -58,15 +58,15 @@
         <div id="geo-info" class="col-lg-3">
             <h4 id="geo-info-name"></h4>
             <dl class="row">
-                <dt class="col-sm-6">Total participants:</dt>
+                <dt class="col-sm-6">Total active participants:</dt>
                 <dd id="geo-info-participants" class="col-sm-2"></dd>
             </dl>
             <dl class="row">
-                <dt class="col-sm-6">Active participants:</dt>
+                <dt class="col-sm-6">Previous active participants:</dt>
                 <dd id="geo-info-active" class="col-sm-2"></dd>
             </dl>
             <dl class="row">
-                <dt class="col-sm-6">New signups:</dt>
+                <dt class="col-sm-6">New active sign-ups:</dt>
                 <dd id="geo-info-newsignups" class="col-sm-2"></dd>
             </dl>
             <dl class="row">


### PR DESCRIPTION
Update the heatmaps labels as discussed on 08/10 to:
- Total active participants
- Previous active participants
- New active sign-ups
- Median steps