### PR TITLE
[1-0] feat: scripts/dummydata.py - a random dummy SQL data generator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,10 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD=trust
     steps:
       - checkout
+      - run:
+          name: Install latest Poetry
+          command: |
+            curl -sSL https://install.python-poetry.org | python3 -
       - restore_cache:
           keys:
             - deps-{{ checksum "poetry.lock" }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.8
+ENV PATH="/root/.local/bin:${PATH}"
 
 # Install postgres client
 RUN wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O - | apt-key add - && \
@@ -11,13 +12,12 @@ RUN wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O - | apt-key ad
 RUN curl https://cli-assets.heroku.com/install.sh | sh
 
 # Install poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+RUN curl -sSL https://install.python-poetry.org | python3 -
 
 # Add files
 ADD . /app
 WORKDIR /app
 
 # Run poetry to install dependencies
-RUN . $HOME/.poetry/env && \
-    poetry config virtualenvs.create false && \
+RUN poetry config virtualenvs.create false && \
     poetry install

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ See [Wiki](https://github.com/sfbrigade/intentional-walk-server/wiki)
 
    It will take a while the first time you run this command to download and
    build the images to run the web application code in a Docker "container".
+   In addition, random database data is generated during this process.
 
 4. Now you should be able to open the web app in your browser at: http://localhost:8000/
 
@@ -85,6 +86,13 @@ server container and perform the following actions within the container CLI.
 
    ```
    # bin/pg_restore_dump <name of backup.dump>
+   ```
+
+ * To generate a random database dump for development
+
+   ```
+   # python scripts/dummydata.py --help
+   # python scripts/dummydata.py > data.dump
    ```
 
 ## Heroku deployment info

--- a/bin/init
+++ b/bin/init
@@ -21,4 +21,17 @@ if [ $RESULT -ne 0 ]; then
   DB_NAME=${DATABASE_URL##*/}
   psql ${DB_HOST} -c "CREATE DATABASE ${DB_NAME};"
   python manage.py migrate
+
+  echo "Generating random SQL data..."
+  sql="$(python3 /app/scripts/dummydata.py --accounts 100)"
+
+  echo "Importing random SQL data..."
+  echo $sql | psql --quiet "${DATABASE_URL}"
+
+  echo "Done importing random SQL data to the new database."
+  echo "To create a superuser, run a bash shell in the \
+intentional-walk-server-server docker container and create one:"
+  echo '    `docker exec -it <container> /bin/bash`
+    `/app# python3 manage.py createsuperuser`
+'
 fi

--- a/bin/init
+++ b/bin/init
@@ -30,8 +30,8 @@ if [ $RESULT -ne 0 ]; then
 
   echo "Done importing random SQL data to the new database."
   echo "To create a superuser, run a bash shell in the \
-intentional-walk-server-server docker container and create one:"
-  echo '    `docker exec -it <container> /bin/bash`
+server docker container and create one:"
+  echo '    `docker compose exec server bash -l`
     `/app# python3 manage.py createsuperuser`
 '
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: postgres:12
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
   server:
     build: .
     env_file:
@@ -12,3 +14,6 @@ services:
       - ${PORT:-8000}:8000
     depends_on:
       - db
+
+volumes:
+  postgres-data: {}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,17 +1,17 @@
 [[package]]
 name = "asgiref"
-version = "3.4.1"
+version = "3.5.2"
 description = "ASGI specs, helper code, and adapters"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
-tests = ["pytest", "pytest-asyncio", "mypy (>=0.800)"]
+tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
 name = "atomicwrites"
-version = "1.4.0"
+version = "1.4.1"
 description = "Atomic file writes."
 category = "main"
 optional = false
@@ -19,17 +19,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "21.2.0"
+version = "22.1.0"
 description = "Classes Without Boilerplate"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.5"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "autoflake"
@@ -42,6 +42,17 @@ python-versions = ">=3.7"
 [package.dependencies]
 pyflakes = ">=1.1.0"
 toml = ">=0.10.2"
+
+[[package]]
+name = "backports.zoneinfo"
+version = "0.2.1"
+description = "Backport of the standard library zoneinfo module"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+tzdata = ["tzdata"]
 
 [[package]]
 name = "black"
@@ -67,19 +78,19 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "certifi"
-version = "2021.10.8"
+version = "2022.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.7"
+version = "2.1.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
-python-versions = ">=3.5.0"
+python-versions = ">=3.6.0"
 
 [package.extras]
 unicode_backport = ["unicodedata2"]
@@ -97,7 +108,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
-version = "0.4.4"
+version = "0.4.5"
 description = "Cross-platform colored terminal text."
 category = "main"
 optional = false
@@ -201,11 +212,11 @@ pyflakes = ">=2.5.0,<2.6.0"
 
 [[package]]
 name = "freezegun"
-version = "1.1.0"
+version = "1.2.2"
 description = "Let your Python tests travel through time"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
 python-dateutil = ">=2.7"
@@ -254,7 +265,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "more-itertools"
-version = "8.11.0"
+version = "8.14.0"
 description = "More routines for operating on iterables, beyond itertools"
 category = "main"
 optional = false
@@ -270,14 +281,14 @@ python-versions = "*"
 
 [[package]]
 name = "packaging"
-version = "21.2"
+version = "21.3"
 description = "Core utilities for Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyparsing = ">=2.0.2,<3"
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pathspec"
@@ -296,8 +307,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
-test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
+docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
 
 [[package]]
 name = "pluggy"
@@ -312,7 +323,7 @@ dev = ["pre-commit", "tox"]
 
 [[package]]
 name = "psycopg2"
-version = "2.9.2"
+version = "2.9.3"
 description = "psycopg2 - Python-PostgreSQL Database Adapter"
 category = "main"
 optional = false
@@ -344,11 +355,14 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "pyparsing"
-version = "2.4.7"
-description = "Python parsing module"
+version = "3.0.9"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
 category = "main"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = ">=3.6.8"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
@@ -423,7 +437,7 @@ cli = ["click (>=5.0)"]
 
 [[package]]
 name = "pytz"
-version = "2021.3"
+version = "2022.2.1"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
@@ -431,21 +445,21 @@ python-versions = "*"
 
 [[package]]
 name = "requests"
-version = "2.26.0"
+version = "2.28.1"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=3.7, <4"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
-idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+charset-normalizer = ">=2,<3"
+idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "six"
@@ -497,15 +511,15 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
-version = "1.26.7"
+version = "1.26.12"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
 [package.extras]
-brotli = ["brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
@@ -538,56 +552,277 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "0b31f6582b3db7971780df23582b68228bdb1dc3b5fc3c97a1d490bc497abf7f"
+content-hash = "3c8c75a472046ef19728153751e6e2e35ec220e21344d4dd227c4500479e1b47"
 
 [metadata.files]
 asgiref = []
 atomicwrites = []
 attrs = []
-autoflake = []
-black = []
+autoflake = [
+    {file = "autoflake-1.5.3-py2.py3-none-any.whl", hash = "sha256:90eb8d3f625bd72068eb670338ea7efcddbc5c6e822d3601e3dc9404c06ea8da"},
+    {file = "autoflake-1.5.3.tar.gz", hash = "sha256:44f7d7eb2c1c49505b513c0e93a5dfd3f7b4218283f50c5ca0af4df6b975d470"},
+]
+"backports.zoneinfo" = [
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:da6013fd84a690242c310d77ddb8441a559e9cb3d3d59ebac9aca1a57b2e18bc"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:89a48c0d158a3cc3f654da4c2de1ceba85263fafb861b98b59040a5086259722"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1c5742112073a563c81f786e77514969acb58649bcdf6cdf0b4ed31a348d4546"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win32.whl", hash = "sha256:e8236383a20872c0cdf5a62b554b27538db7fa1bbec52429d8d106effbaeca08"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:8439c030a11780786a2002261569bdf362264f605dfa4d65090b64b05c9f79a7"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:17746bd546106fa389c51dbea67c8b7c8f0d14b5526a579ca6ccf5ed72c526cf"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5c144945a7752ca544b4b78c8c41544cdfaf9786f25fe5ffb10e838e19a27570"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win32.whl", hash = "sha256:e55b384612d93be96506932a786bbcde5a2db7a9e6a4bb4bffe8b733f5b9036b"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a76b38c52400b762e48131494ba26be363491ac4f9a04c1b7e92483d169f6582"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:8961c0f32cd0336fb8e8ead11a1f8cd99ec07145ec2931122faaac1c8f7fd987"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e81b76cace8eda1fca50e345242ba977f9be6ae3945af8d46326d776b4cf78d1"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7b0a64cda4145548fed9efc10322770f929b944ce5cee6c0dfe0c87bf4c0c8c9"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win32.whl", hash = "sha256:1b13e654a55cd45672cb54ed12148cd33628f672548f373963b0bff67b217328"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:4a0f800587060bf8880f954dbef70de6c11bbe59c673c3d818921f042f9954a6"},
+    {file = "backports.zoneinfo-0.2.1.tar.gz", hash = "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"},
+]
+black = [
+    {file = "black-22.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ce957f1d6b78a8a231b18e0dd2d94a33d2ba738cd88a7fe64f53f659eea49fdd"},
+    {file = "black-22.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5107ea36b2b61917956d018bd25129baf9ad1125e39324a9b18248d362156a27"},
+    {file = "black-22.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e8166b7bfe5dcb56d325385bd1d1e0f635f24aae14b3ae437102dedc0c186747"},
+    {file = "black-22.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd82842bb272297503cbec1a2600b6bfb338dae017186f8f215c8958f8acf869"},
+    {file = "black-22.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:d839150f61d09e7217f52917259831fe2b689f5c8e5e32611736351b89bb2a90"},
+    {file = "black-22.8.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:a05da0430bd5ced89176db098567973be52ce175a55677436a271102d7eaa3fe"},
+    {file = "black-22.8.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a098a69a02596e1f2a58a2a1c8d5a05d5a74461af552b371e82f9fa4ada8342"},
+    {file = "black-22.8.0-cp36-cp36m-win_amd64.whl", hash = "sha256:5594efbdc35426e35a7defa1ea1a1cb97c7dbd34c0e49af7fb593a36bd45edab"},
+    {file = "black-22.8.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a983526af1bea1e4cf6768e649990f28ee4f4137266921c2c3cee8116ae42ec3"},
+    {file = "black-22.8.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b2c25f8dea5e8444bdc6788a2f543e1fb01494e144480bc17f806178378005e"},
+    {file = "black-22.8.0-cp37-cp37m-win_amd64.whl", hash = "sha256:78dd85caaab7c3153054756b9fe8c611efa63d9e7aecfa33e533060cb14b6d16"},
+    {file = "black-22.8.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:cea1b2542d4e2c02c332e83150e41e3ca80dc0fb8de20df3c5e98e242156222c"},
+    {file = "black-22.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5b879eb439094751185d1cfdca43023bc6786bd3c60372462b6f051efa6281a5"},
+    {file = "black-22.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0a12e4e1353819af41df998b02c6742643cfef58282915f781d0e4dd7a200411"},
+    {file = "black-22.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3a73f66b6d5ba7288cd5d6dad9b4c9b43f4e8a4b789a94bf5abfb878c663eb3"},
+    {file = "black-22.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:e981e20ec152dfb3e77418fb616077937378b322d7b26aa1ff87717fb18b4875"},
+    {file = "black-22.8.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8ce13ffed7e66dda0da3e0b2eb1bdfc83f5812f66e09aca2b0978593ed636b6c"},
+    {file = "black-22.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:32a4b17f644fc288c6ee2bafdf5e3b045f4eff84693ac069d87b1a347d861497"},
+    {file = "black-22.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0ad827325a3a634bae88ae7747db1a395d5ee02cf05d9aa7a9bd77dfb10e940c"},
+    {file = "black-22.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:53198e28a1fb865e9fe97f88220da2e44df6da82b18833b588b1883b16bb5d41"},
+    {file = "black-22.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:bc4d4123830a2d190e9cc42a2e43570f82ace35c3aeb26a512a2102bce5af7ec"},
+    {file = "black-22.8.0-py3-none-any.whl", hash = "sha256:d2c21d439b2baf7aa80d6dd4e3659259be64c6f49dfd0f32091063db0e006db4"},
+    {file = "black-22.8.0.tar.gz", hash = "sha256:792f7eb540ba9a17e8656538701d3eb1afcb134e3b45b71f20b25c77a8db7e6e"},
+]
 certifi = []
-charset-normalizer = []
+charset-normalizer = [
+    {file = "charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"},
+    {file = "charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"},
+]
 click = []
-colorama = []
-coverage = []
-coveralls = []
-dj-database-url = []
-django = []
-django-postgres-setfield = []
-docopt = []
-faker = []
-flake8 = []
-freezegun = []
-gunicorn = []
-idna = []
-libfaketime = []
-mccabe = []
-more-itertools = []
-mypy-extensions = []
-packaging = []
-pathspec = []
-platformdirs = []
-pluggy = []
-psycopg2 = []
-py = []
-pycodestyle = []
-pyflakes = []
-pyparsing = []
-pytest = []
-pytest-django = []
-pytest-libfaketime = []
-python-dateutil = []
-python-dotenv = []
-pytz = []
+colorama = [
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+]
+coverage = [
+    {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c"},
+    {file = "coverage-5.5-cp27-cp27m-win32.whl", hash = "sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a"},
+    {file = "coverage-5.5-cp27-cp27m-win_amd64.whl", hash = "sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81"},
+    {file = "coverage-5.5-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6"},
+    {file = "coverage-5.5-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0"},
+    {file = "coverage-5.5-cp310-cp310-win_amd64.whl", hash = "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae"},
+    {file = "coverage-5.5-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793"},
+    {file = "coverage-5.5-cp35-cp35m-win32.whl", hash = "sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e"},
+    {file = "coverage-5.5-cp35-cp35m-win_amd64.whl", hash = "sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3"},
+    {file = "coverage-5.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821"},
+    {file = "coverage-5.5-cp36-cp36m-win32.whl", hash = "sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45"},
+    {file = "coverage-5.5-cp36-cp36m-win_amd64.whl", hash = "sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184"},
+    {file = "coverage-5.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3"},
+    {file = "coverage-5.5-cp37-cp37m-win32.whl", hash = "sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a"},
+    {file = "coverage-5.5-cp37-cp37m-win_amd64.whl", hash = "sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a"},
+    {file = "coverage-5.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6"},
+    {file = "coverage-5.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2"},
+    {file = "coverage-5.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759"},
+    {file = "coverage-5.5-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873"},
+    {file = "coverage-5.5-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a"},
+    {file = "coverage-5.5-cp38-cp38-win32.whl", hash = "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6"},
+    {file = "coverage-5.5-cp38-cp38-win_amd64.whl", hash = "sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502"},
+    {file = "coverage-5.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b"},
+    {file = "coverage-5.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529"},
+    {file = "coverage-5.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b"},
+    {file = "coverage-5.5-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff"},
+    {file = "coverage-5.5-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b"},
+    {file = "coverage-5.5-cp39-cp39-win32.whl", hash = "sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6"},
+    {file = "coverage-5.5-cp39-cp39-win_amd64.whl", hash = "sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03"},
+    {file = "coverage-5.5-pp36-none-any.whl", hash = "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079"},
+    {file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4"},
+    {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
+]
+coveralls = [
+    {file = "coveralls-1.11.1-py2.py3-none-any.whl", hash = "sha256:4b6bfc2a2a77b890f556bc631e35ba1ac21193c356393b66c84465c06218e135"},
+    {file = "coveralls-1.11.1.tar.gz", hash = "sha256:67188c7ec630c5f708c31552f2bcdac4580e172219897c4136504f14b823132f"},
+]
+dj-database-url = [
+    {file = "dj-database-url-0.5.0.tar.gz", hash = "sha256:4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163"},
+    {file = "dj_database_url-0.5.0-py2.py3-none-any.whl", hash = "sha256:851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9"},
+]
+django = [
+    {file = "Django-3.2.15-py3-none-any.whl", hash = "sha256:115baf5049d5cf4163e43492cdc7139c306ed6d451e7d3571fe9612903903713"},
+    {file = "Django-3.2.15.tar.gz", hash = "sha256:f71934b1a822f14a86c9ac9634053689279cd04ae69cb6ade4a59471b886582b"},
+]
+django-postgres-setfield = [
+    {file = "django-postgres-setfield-0.0.1.tar.gz", hash = "sha256:99041c82ead927d0e28a5f154fcf99c4666600314780cd8c8adbe061f33eb923"},
+    {file = "django_postgres_setfield-0.0.1-py3-none-any.whl", hash = "sha256:e7d17ae5405933e65415baf6c4a2cf1f2d62ccf1281d807eed3b1e87d3c73740"},
+]
+docopt = [
+    {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
+]
+faker = [
+    {file = "Faker-8.16.0-py3-none-any.whl", hash = "sha256:bb10913b9d3ac2aa37180f816c82040e81f9e0c32cb08445533f293cec8930bf"},
+    {file = "Faker-8.16.0.tar.gz", hash = "sha256:d70b375d0af0e4c3abd594003691a1055a96281a414884e623d27bccc7d781da"},
+]
+flake8 = [
+    {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
+    {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
+]
+freezegun = [
+    {file = "freezegun-1.2.2-py3-none-any.whl", hash = "sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f"},
+    {file = "freezegun-1.2.2.tar.gz", hash = "sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446"},
+]
+gunicorn = [
+    {file = "gunicorn-20.1.0-py3-none-any.whl", hash = "sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e"},
+    {file = "gunicorn-20.1.0.tar.gz", hash = "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"},
+]
+idna = [
+    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
+    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+]
+libfaketime = [
+    {file = "libfaketime-2.0.0.tar.gz", hash = "sha256:a63b3f359f6f15f7b814ebfe1e4a9642bd481178223f0d97aab1a537475876df"},
+]
+mccabe = [
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+]
+more-itertools = [
+    {file = "more-itertools-8.14.0.tar.gz", hash = "sha256:c09443cd3d5438b8dafccd867a6bc1cb0894389e90cb53d227456b0b0bccb750"},
+    {file = "more_itertools-8.14.0-py3-none-any.whl", hash = "sha256:1bc4f91ee5b1b31ac7ceacc17c09befe6a40a503907baf9c839c229b5095cfd2"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
+pathspec = [
+    {file = "pathspec-0.10.1-py3-none-any.whl", hash = "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93"},
+    {file = "pathspec-0.10.1.tar.gz", hash = "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"},
+]
+platformdirs = [
+    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
+    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
+]
+pluggy = [
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+psycopg2 = [
+    {file = "psycopg2-2.9.3-cp310-cp310-win32.whl", hash = "sha256:083707a696e5e1c330af2508d8fab36f9700b26621ccbcb538abe22e15485362"},
+    {file = "psycopg2-2.9.3-cp310-cp310-win_amd64.whl", hash = "sha256:d3ca6421b942f60c008f81a3541e8faf6865a28d5a9b48544b0ee4f40cac7fca"},
+    {file = "psycopg2-2.9.3-cp36-cp36m-win32.whl", hash = "sha256:9572e08b50aed176ef6d66f15a21d823bb6f6d23152d35e8451d7d2d18fdac56"},
+    {file = "psycopg2-2.9.3-cp36-cp36m-win_amd64.whl", hash = "sha256:a81e3866f99382dfe8c15a151f1ca5fde5815fde879348fe5a9884a7c092a305"},
+    {file = "psycopg2-2.9.3-cp37-cp37m-win32.whl", hash = "sha256:cb10d44e6694d763fa1078a26f7f6137d69f555a78ec85dc2ef716c37447e4b2"},
+    {file = "psycopg2-2.9.3-cp37-cp37m-win_amd64.whl", hash = "sha256:4295093a6ae3434d33ec6baab4ca5512a5082cc43c0505293087b8a46d108461"},
+    {file = "psycopg2-2.9.3-cp38-cp38-win32.whl", hash = "sha256:34b33e0162cfcaad151f249c2649fd1030010c16f4bbc40a604c1cb77173dcf7"},
+    {file = "psycopg2-2.9.3-cp38-cp38-win_amd64.whl", hash = "sha256:0762c27d018edbcb2d34d51596e4346c983bd27c330218c56c4dc25ef7e819bf"},
+    {file = "psycopg2-2.9.3-cp39-cp39-win32.whl", hash = "sha256:8cf3878353cc04b053822896bc4922b194792df9df2f1ad8da01fb3043602126"},
+    {file = "psycopg2-2.9.3-cp39-cp39-win_amd64.whl", hash = "sha256:06f32425949bd5fe8f625c49f17ebb9784e1e4fe928b7cce72edc36fb68e4c0c"},
+    {file = "psycopg2-2.9.3.tar.gz", hash = "sha256:8e841d1bf3434da985cc5ef13e6f75c8981ced601fd70cc6bf33351b91562981"},
+]
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
+    {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
+]
+pyflakes = [
+    {file = "pyflakes-2.5.0-py2.py3-none-any.whl", hash = "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2"},
+    {file = "pyflakes-2.5.0.tar.gz", hash = "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"},
+]
+pyparsing = [
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
+]
+pytest = [
+    {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},
+    {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
+]
+pytest-django = [
+    {file = "pytest-django-3.10.0.tar.gz", hash = "sha256:4de6dbd077ed8606616958f77655fed0d5e3ee45159475671c7fa67596c6dba6"},
+    {file = "pytest_django-3.10.0-py2.py3-none-any.whl", hash = "sha256:c33e3d3da14d8409b125d825d4e74da17bb252191bf6fc3da6856e27a8b73ea4"},
+]
+pytest-libfaketime = [
+    {file = "pytest-libfaketime-0.1.2.tar.gz", hash = "sha256:01f4fd849c6ce6d25506b6a0c007333aeef4111a061ddd02062a34757d75fa25"},
+    {file = "pytest_libfaketime-0.1.2-py2.py3-none-any.whl", hash = "sha256:a65f5cee9d23a5189b8c034bd685ce76a8879fe7d0b4a9747c78b7e6cde1d9ac"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+python-dotenv = [
+    {file = "python-dotenv-0.11.0.tar.gz", hash = "sha256:8429f459fc041237d98c9ff32e1938e7e5535b5ff24388876315a098027c3a57"},
+    {file = "python_dotenv-0.11.0-py2.py3-none-any.whl", hash = "sha256:ca9f3debf2262170d6f46571ce4d6ca1add60bb93b69c3a29dcb3d1a00a65c93"},
+]
+pytz = [
+    {file = "pytz-2022.2.1-py2.py3-none-any.whl", hash = "sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197"},
+    {file = "pytz-2022.2.1.tar.gz", hash = "sha256:cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5"},
+]
 requests = []
-six = []
-sqlparse = []
-text-unidecode = []
-toml = []
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+sqlparse = [
+    {file = "sqlparse-0.4.2-py3-none-any.whl", hash = "sha256:48719e356bb8b42991bdbb1e8b83223757b93789c00910a616a071910ca4a64d"},
+    {file = "sqlparse-0.4.2.tar.gz", hash = "sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae"},
+]
+text-unidecode = [
+    {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
+    {file = "text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8"},
+]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
 tomli = []
 typing-extensions = []
-urllib3 = []
-uuid = []
-wcwidth = []
-whitenoise = []
+urllib3 = [
+    {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
+    {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
+]
+uuid = [
+    {file = "uuid-1.30.tar.gz", hash = "sha256:1f87cc004ac5120466f36c5beae48b4c48cc411968eed0eaecd3da82aa96193f"},
+]
+wcwidth = [
+    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
+    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
+]
+whitenoise = [
+    {file = "whitenoise-5.3.0-py2.py3-none-any.whl", hash = "sha256:d963ef25639d1417e8a247be36e6aedd8c7c6f0a08adcb5a89146980a96b577c"},
+    {file = "whitenoise-5.3.0.tar.gz", hash = "sha256:d234b871b52271ae7ed6d9da47ffe857c76568f11dd30e28e18c5869dbd11e12"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ django-postgres-setfield = "^0.0.1"
 black = "^22.8.0"
 flake8 = "^5.0.4"
 autoflake = "^1.5.3"
+"backports.zoneinfo" = { version = "^0.2.1", python = "<3.9" }
 
 [tool.poetry.dev-dependencies]
 freezegun = "^1.1.0"

--- a/scripts/dummydata.py
+++ b/scripts/dummydata.py
@@ -1,0 +1,619 @@
+"""
+Generate dummy data to be imported into a clean database.
+Once generated, a user can import the resulting text into
+their postgresql instance.
+
+Import dummy data into a fresh database:
+
+    $ python scripts/dummydata.py --accounts 500 > iw_db.sql
+    $ createdb iw_db
+    $ python manage.py migrate
+    $ psql iw_db < iw_db.sql
+    [...this will take a while]
+
+After this, a user should generate an admin account:
+
+    $ python manage.py createsuperuser
+    [...fills out a form]
+
+You can then continue on to running the server with the new database.
+
+Run this script with `--help` for a list of options.
+"""
+import argparse
+import binascii
+import os
+import sys
+import traceback
+from calendar import monthrange
+from collections import OrderedDict
+from datetime import date, datetime
+from random import randint
+from typing import Any, Dict, List, Tuple
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
+
+from dateutil.relativedelta import relativedelta
+
+# All San Francisco zip codes based on:
+# https://www.usmapguide.com/california/san-francisco-zip-code-map/
+ZIP_CODES = [
+    94102,
+    94103,
+    94104,
+    94105,
+    94107,
+    94108,
+    94109,
+    94110,
+    94111,
+    94112,
+    94114,
+    94115,
+    94116,
+    94117,
+    94118,
+    94121,
+    94122,
+    94123,
+    94124,
+    94127,
+    94129,
+    94130,
+    94131,
+    94132,
+    94133,
+    94134,
+    94158,
+]
+
+RACES = [
+    "NA",  # American Indian or Alaska Native
+    "BL",  # Black
+    "AS",  # Asian
+    "PI",  # Native Hawaiian or other Pacific Islander
+    "WH",  # White
+    "OT",  # Other
+    "DA",  # Decline to answer
+]
+
+GENDERS = [
+    "CF",  # "Female"
+    "CM",  # "Male"
+    "TF",  # "Trans Female"
+    "TM",  # "Trans Male"
+    "NB",  # "Non-binary"
+    "OT",  # "Other"
+    "DA",  # "Decline to answer"
+]
+
+ORIENTATION = [
+    "BS",  # "Bisexual"
+    "SG",  # "SameGenderLoving"
+    "US",  # "Unsure"
+    "HS",  # "Heterosexual"
+    "OT",  # "Other"
+    "DA",  # "Decline to answer"
+]
+
+IS_LATINO = [
+    "YE",  # "Yes"
+    "NO",  # "No"
+    "DA",  # "Decline to answer"
+]
+
+TIMEZONE = None
+
+TYPE_FORMATS = {
+    str: "'%s'",
+    int: "%d",
+    float: "%.6f",
+    bool: "%s",
+    date: "'%s'",
+    list: "%s",
+}
+
+TYPE_TRANSFORM = {
+    str: lambda x: x,
+    int: lambda x: x,
+    float: lambda x: x,
+    bool: lambda x: str(x).lower(),
+    date: lambda x: str(x),
+    list: lambda x: f"{{{', '.join(x)}}}",
+}
+
+
+def random_element(array: List[Any]):
+    n = randint(0, len(array) - 1)
+    return array[n]
+
+
+def type_fmt(value: Any) -> Any:
+    transform = TYPE_TRANSFORM.get(type(value))
+    return TYPE_FORMATS.get(type(transform(value)))
+
+
+def insert(table: str, **kwargs) -> Tuple[str, Tuple[Any]]:
+    """Generate an SQL insert statement based on `kwargs`"""
+    args = OrderedDict(**kwargs)
+    values = [arg for arg in args.values() if arg is not None]
+
+    def transform(x):
+        return TYPE_TRANSFORM[type(x)](x)
+
+    def _(k):
+        return f'"{k}"'
+
+    return (
+        f"INSERT INTO {table} "
+        f"({', '.join([_(k) for k in args.keys() if args[k] is not None])})"
+        " VALUES "
+        f"({', '.join([type_fmt(v) for v in values if v is not None])});"
+    ) % tuple([transform(v) for v in values])
+
+
+def random_race():
+    return [random_element(RACES)]
+
+
+def random_age():
+    return randint(18, 55)
+
+
+def random_zip():
+    return random_element(ZIP_CODES)
+
+
+def random_gender():
+    return random_element(GENDERS)
+
+
+def random_orientation():
+    return random_element(ORIENTATION)
+
+
+def random_is_latino():
+    return random_element(IS_LATINO)
+
+
+def random_string(n: int):
+    if n % 2 != 0:
+        raise ValueError("random_string(n): n % 2 == 0 must be true")
+    return binascii.b2a_hex(os.urandom(int(n / 2))).decode()
+
+
+class SQLGenerator:
+    accounts = list()
+    devices = dict()
+    contests = OrderedDict()
+
+    def __init__(self):
+        pass
+
+    def account(self, **kwargs) -> Tuple[str, Tuple[Any]]:
+        dt = datetime.now(tz=TIMEZONE)
+
+        start_point = int((dt - relativedelta(months=11)).timestamp())
+        end_point = int((dt - relativedelta(days=2)).timestamp())
+
+        created_ts = randint(start_point, end_point)
+        created = datetime.fromtimestamp(created_ts, TIMEZONE)
+
+        args = OrderedDict(kwargs)
+        acct = dict(args)
+        acct.update(
+            {
+                "created": created,
+                "updated": dt,
+            }
+        )
+        self.accounts.append(acct)
+
+        return insert(
+            "home_account",
+            id=args.get("id"),
+            email=args.get("email"),
+            name=args.get("name"),
+            zip=args.get("zip"),
+            age=args.get("age"),
+            created=created.strftime("%Y-%m-%d %H:%M:%S (%Z)"),
+            updated=dt.strftime("%Y-%m-%d %H:%M:%S (%Z)"),
+            is_sf_resident=args.get("is_sf_resident"),
+            is_latino=args.get("is_latino"),
+            gender=args.get("gender"),
+            is_tester=args.get("is_tester", False),
+            gender_other=args.get("gender_other", "N/A"),
+            race_other=args.get("race_other", "N/A"),
+            race=args.get("race"),
+            sexual_orien=args.get("sexual_orien"),
+            sexual_orien_other=args.get("sexual_orien_other", "N/A"),
+        )
+
+    def contest(self, **kwargs) -> Tuple[str, Tuple[Any]]:
+        contest_id = kwargs.get("contest_id")
+        if contest_id in self.contests:
+            raise KeyError(f"Contest '{contest_id}' already exists.")
+
+        self.contests[contest_id] = (kwargs.get("start"), kwargs.get("end"))
+
+        return insert(
+            "home_contest",
+            contest_id=kwargs.get("contest_id", None),
+            start=kwargs.get("start"),  # date
+            end=kwargs.get("end"),  # date
+            start_promo=kwargs.get("start_promo"),  # date
+            created=kwargs.get("created", None),  # timestamp with timezone
+            updated=kwargs.get("updated", None),  # timestamp with timezone
+            start_baseline=kwargs.get("start_baseline"),  # date
+        )
+
+    def account_contest(self, **kwargs) -> Tuple[str, Tuple[Any]]:
+        return insert(
+            "home_account_contests",
+            account_id=kwargs.get("account_id"),
+            contest_id=kwargs.get("contest_id"),
+        )
+
+    def device(self, **kwargs) -> Tuple[str, Tuple[Any]]:
+        dev_id = kwargs.get("device_id")
+
+        if dev_id in self.devices:
+            raise KeyError(f"Device '{dev_id}' already exists.")
+
+        account_id = kwargs.get("account_id")
+        self.devices[account_id] = dev_id
+
+        dt = datetime.now(tz=TIMEZONE)
+        return insert(
+            "home_device",
+            device_id=dev_id,  # Required UID string
+            created=dt.strftime("%Y-%m-%d %H:%M:%S (%Z)"),
+            account_id=account_id,
+        )
+
+    def daily_walk(self, **kwargs) -> Tuple[str, Tuple[Any]]:
+        return insert(
+            "home_dailywalk",
+            date=kwargs.get("date"),  # date
+            steps=kwargs.get("steps"),
+            distance=kwargs.get("distance"),  # double
+            created=kwargs.get("created", None),  # timestamp with timezone
+            updated=kwargs.get("updated", None),  # timestamp with timezone
+            account_id=kwargs.get("account_id"),  # int
+            device_id=kwargs.get("device_id"),  # str
+        )
+
+    def intentional_walk(self, **kwargs) -> Tuple[str, Tuple[Any]]:
+        return insert(
+            "home_intentionalwalk",
+            event_id=kwargs.get("event_id"),  # str
+            start=kwargs.get("start"),  # timestamp with timezone
+            end=kwargs.get("end"),  # timestamp with timezone
+            steps=kwargs.get("steps"),  # double
+            pause_time=kwargs.get("pause_time"),  # double
+            distance=kwargs.get("distance"),  # double
+            created=kwargs.get("created", None),  # timestamp with timezone
+            account_id=kwargs.get("account_id"),  # int
+            device_id=kwargs.get("device_id", None),  # str
+        )
+
+    def make_accounts(self, n: int) -> Tuple[List[str], List[int]]:
+        """
+        Generate SQL statements to insert `n` random accounts.
+
+        Each account is created at a random time between the beginning of
+        of the first contest and the end of the most recent contest.
+        Randomized values are used for nearly all fields, with the
+        exception of `id`, `email` and `name`, which use the iteration
+        index `id` to set their values. All accounts generated
+        through this function are known as SF residents via
+        `is_sf_resident=True`.
+
+        :returns: [outputs, account_ids]
+                  outputs     - list of SQL insert strings
+                  account_ids - list[int] of account IDs used in `outputs`
+        """
+        global accounts
+
+        account_ids, outputs = [], []
+        for id in range(1, n + 1):
+            account_ids.append(id)
+            output = self.account(
+                id=id,
+                email=f"user{id}@example.com",
+                name=f"User {id}",
+                zip=random_zip(),
+                age=random_age(),
+                is_sf_resident=True,
+                is_latino=random_is_latino(),
+                race=random_race(),
+                gender=random_gender(),
+                sexual_orien=random_orientation(),
+            )
+            outputs.append(output)
+
+        self.accounts.sort(key=lambda x: x["created"])
+        return [outputs, account_ids]
+
+    def make_contests(
+        self,
+        n: int,
+    ) -> Tuple[List[str], List[int], Dict[int, datetime]]:
+        """Generate SQL statements to insert 3 random contest records."""
+        # Create a few contests with consecutive ranges up until the
+        # current month at the time this is executed.
+
+        # Put ourselves ahead by one month for contest-range purposes.
+        # This will give our data some realistic range, as if we're
+        # somewhat in the middle of a contest.
+        dt = datetime.now(tz=TIMEZONE) + relativedelta(months=1)
+        outputs, contest_ids = [], []
+        contest_times = dict()
+        delta = 0
+        for i in range(n):
+            while True:
+
+                # The start is three months before the end.
+                start = dt - relativedelta(months=delta + 3)
+                # Set `start` to the beginning of the month.
+                r = monthrange(start.year, start.month)
+                start -= relativedelta(days=max(start.day - 2, 1))
+
+                end = dt - relativedelta(months=delta)
+                # Set `end` to the end of the month.
+                r = monthrange(end.year, end.month)
+                end += relativedelta(days=r[1] - end.day)
+
+                # Make the promo start 5 days before the contest.
+                start_promo = start - relativedelta(days=5)
+                start_baseline = start - relativedelta(days=1)
+
+                try:
+                    contest_id = "-".join([random_string(8) for i in range(4)])
+                    output = self.contest(
+                        contest_id=contest_id,
+                        start=start.date(),
+                        end=end.date(),
+                        start_promo=start_promo.date(),
+                        created=start.strftime("%Y-%m-%d %H:%M:%S (%Z)"),
+                        updated=end.strftime("%Y-%m-%d %H:%M:%S (%Z)"),
+                        start_baseline=start_baseline.date(),
+                    )
+                except KeyError:
+                    continue
+
+                contest_ids.append(contest_id)
+                contest_times[contest_id] = (start, end)
+                break
+
+            outputs.append(output)
+
+            # Increment the delta for the next contest period.
+            delta += 4
+
+        return [outputs, contest_ids, contest_times]
+
+    def make_account_contests(self) -> List[List[str]]:
+        """Generate SQL statements to insert account_contests relationships."""
+        outputs = []
+        for acct in self.accounts:
+            created = acct.get("created").date()
+            for contest_id, dt in self.contests.items():
+                start, end = dt
+                if created >= start and created <= end:
+                    outputs.append(
+                        self.account_contest(
+                            account_id=acct.get("id"), contest_id=contest_id
+                        )
+                    )
+        return [outputs]
+
+    def make_devices(
+        self, account_ids: List[int]
+    ) -> Tuple[List[str], Dict[int, str]]:
+        """Generate SQL statements to insert a device for each `account_id`"""
+        n = len(account_ids)
+        outputs = []
+        devices = dict()
+        # Give a device to every account.
+        for id in range(1, n + 1):
+            account_id = account_ids[id - 1]
+            output = None
+            while True:
+                try:
+                    dev_id = random_string(8)
+                    output = self.device(
+                        device_id=dev_id, account_id=account_id
+                    )
+                except ValueError:
+                    continue
+                devices[account_id] = dev_id
+                break
+            outputs.append(output)
+        return [outputs, devices]
+
+    def make_dailywalks(self, devices: Dict[int, str]) -> List[List[str]]:
+        """Generate SQL statements to insert random daily walk records"""
+        tmp_accounts = self.accounts
+
+        first = tmp_accounts[0].get("created")
+        dt = first
+        end = datetime.now(tz=TIMEZONE)
+        tracked = []
+        outputs = []
+        while dt < end:
+            dt += relativedelta(days=1)
+
+            i = 0
+            n = len(tmp_accounts)
+            while i < n:
+                acct = tmp_accounts[i]
+
+                if acct.get("created") <= dt:
+                    tracked.append(acct)
+                    tmp_accounts = tmp_accounts[1:]
+                    n = len(tmp_accounts)
+                    i -= 1
+
+                    if i < 0:
+                        i = 0
+                else:
+                    break
+
+            for acct in tracked:
+                account_id = acct.get("id")
+                steps = randint(500, 7500)
+                output = self.daily_walk(
+                    date=dt.date(),
+                    steps=steps,
+                    # Google says average walk is 0.7km per 1000 steps.
+                    # So, we approximate here based on the number of steps.
+                    distance=steps * (0.7 / 1000),
+                    created=dt.strftime("%Y-%m-%d %H:%M:%S (%Z)"),
+                    updated=dt.strftime("%Y-%m-%d %H:%M:%S (%Z)"),
+                    account_id=account_id,
+                    device_id=devices.get(account_id),
+                )
+
+                outputs.append(output)
+
+        return [outputs]
+
+    def make_intentionalwalks(
+        self, devices: Dict[int, str]
+    ) -> List[List[str]]:
+        """Generate SQL statements to insert random intentional walk records"""
+        tmp_accounts = self.accounts
+        first = tmp_accounts[0].get("created")
+        dt = first
+        end = datetime.now(tz=TIMEZONE)
+        events = set()
+        outputs, tracked = [], []
+        while dt < end - relativedelta(days=5):
+            dt += relativedelta(days=1)
+
+            i = 0
+            n = len(tmp_accounts)
+            while i < n:
+                acct = tmp_accounts[i]
+
+                if acct.get("created") < dt:
+                    tracked.append(acct)
+                    tmp_accounts = tmp_accounts[1:]
+                    n = len(tmp_accounts)
+                    i -= 1
+
+                    if i < 0:
+                        i = 0
+                else:
+                    break
+
+            for acct in tracked:
+                account_id = acct.get("id")
+                steps = randint(500, 7500)
+
+                start_ts = int(dt.timestamp())
+                now = datetime.now(tz=TIMEZONE)
+                end_ts = int(now.timestamp())
+
+                # Determine a random start time from start to now - 5 hours.
+                start_ts = randint(start_ts, end_ts - 5 * 60 * 60)
+
+                # Walk for at least 30 minutes up until 4 hours.
+                end_ts = randint(
+                    start_ts + 1 * 60 * 30, start_ts + 4 * 60 * 60
+                )
+
+                start_time = datetime.fromtimestamp(start_ts, tz=TIMEZONE)
+                start_fmt = start_time.strftime("%Y-%m-%d %H:%M:%S (%Z)")
+
+                end_time = datetime.fromtimestamp(end_ts, tz=TIMEZONE)
+                end_fmt = end_time.strftime("%Y-%m-%d %H:%M:%S (%Z)")
+
+                event_id = "-".join([random_string(8) for i in range(4)])
+                while event_id in events:
+                    event_id = "-".join([random_string(8) for i in range(4)])
+
+                events.add(event_id)
+                output = self.intentional_walk(
+                    event_id=event_id,
+                    date=dt.date(),
+                    steps=steps,
+                    start=start_fmt,
+                    end=end_fmt,
+                    pause_time=0.0,
+                    # Google says average walk is 0.7km per 1000 steps.
+                    # So, we approximate here based on the number of steps.
+                    distance=steps * (0.7 / 1000),
+                    created=end_fmt,
+                    account_id=account_id,
+                    device_id=devices.get(account_id),
+                )
+
+                outputs.append(output)
+
+        return [outputs]
+
+
+def set_timezone(tz: str) -> None:
+    global TIMEZONE
+    TIMEZONE = ZoneInfo(tz)
+
+
+def main() -> int:
+    """Main execution entrypoint."""
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "-a",
+        "--accounts",
+        default=250,
+        type=int,
+        help="number of walker accounts to generate (default: 250)",
+    )
+    p.add_argument(
+        "-t",
+        "--timezone",
+        default="UTC",
+        type=str,
+        help=(
+            "timezone used, should match your django "
+            "settings.py timezone (default: 'UTC')"
+        ),
+    )
+    args = p.parse_args()
+
+    # Setup constants configured via arguments
+    set_timezone(args.timezone)
+
+    # Generate SQL statements
+    sql = SQLGenerator()
+    outputs, account_ids = sql.make_accounts(args.accounts)
+    print("\n".join(outputs))
+
+    outputs, contest_ids, contest_times = sql.make_contests(3)
+    print("\n".join(outputs))
+
+    (outputs,) = sql.make_account_contests()
+    print("\n".join(outputs))
+
+    outputs, devices = sql.make_devices(account_ids)
+    print("\n".join(outputs))
+
+    (outputs,) = sql.make_dailywalks(devices)
+    print("\n".join(outputs))
+
+    (outputs,) = sql.make_intentionalwalks(devices)
+    print("\n".join(outputs))
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
This script can be used by developers to generate some initial
random data into their local Intentional Walk databases.

See `python scripts/dummydata.py --help` for a list of options.

Importing dummy data into a new local postgres database:

    $ python scripts/dummydata.py > iw_db.sql
    $ createdb iw_db
    $ python manage.py migrate
    $ psql iw_db < iw_db.sql
    [...takes a while]
    $ python manage.py createsuperuser
    [...]
    $ python manage.py runserver
    [...server starts]

Signed-off-by: Kevin Morris <kevr@0cost.org>