### PR TITLE
feat(ci): install setuptools via pip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
+            pip install setuptools
             poetry install
       - save_cache:
           key: deps-{{ checksum "poetry.lock" }}


### PR DESCRIPTION
Looks like something changed in the dependency set which was
causing CI to fail installing dependencies through poetry due
to not having a setuptools module available.

This patch to Circle CI's config installs setuptools directly
into the virtualenv we're using before installing via poetry,
which resolves the issue.

Signed-off-by: Kevin Morris <kevr@0cost.org>

