### PR TITLE
fix(users): default numeric columns for users with no walks to 0

### DIFF
--- a/home/views/web/user.py
+++ b/home/views/web/user.py
@@ -191,9 +191,17 @@ class UserListView(generic.ListView):
 
             # Find everyone who signed up during the constest
             for acct in get_new_signups(contest, include_testers):
+
+                # If this account hasn't performed a daily walk yet:
                 if acct["email"] not in daily_walks:
+
+                    # Provide some sane defaults for them
                     user_stats_container[acct["email"]] = dict(
-                        new_signup=True, account=acct
+                        new_signup=True,
+                        account=acct,
+                        num_dws=0,
+                        dw_steps=0,
+                        dw_distance=0,
                     )
                     new_signups_by_zip[acct["zip"]] += 1
 


### PR DESCRIPTION
This was a bit confusing: before this commit, the backend users page displays new signups whether they've walked or not, but in cases where they have not walked at all, no numeric value is displayed.

Anyway, TL;DR: This commit defaults numeric columns in user rows with no walks to 0, which indicates that the user hasn't walked and makes a bit more sense.

Signed-off-by: Kevin Morris <kevr@0cost.org>