### PR TITLE
Coverage/coveralls Issue #158

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,7 @@ jobs:
           DATABASE_URL: "postgresql://postgres@localhost/webtool"
           SECRET_KEY: "secretkey"
       - image: cimg/postgres:11.17
-        environment:
-          POSTGRES_HOST_AUTH_METHOD=trust
+        environment: POSTGRES_HOST_AUTH_METHOD=trust
     steps:
       - checkout
       - run:
@@ -39,7 +38,7 @@ jobs:
       - run:
           name: Run Pytest, report coverage
           command: |
-            poetry run coverage run --omit="/home/circleci/.cache/pypoetry/virtualenvs/*" -m pytest
+            make coverage
             poetry run coveralls
 workflows:
   main:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+source = home
+omit = 
+  *migrations*
+  *tests*
+  *.cache/

--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.devcontainer
 
 # Spyder project settings
 .spyderproject

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: test coverage
+
+test:
+	@echo "Running tests"
+	@poetry run pytest
+
+coverage:
+	@echo "Running tests with coverage"
+	@poetry run scripts/coverage_html.py

--- a/README.md
+++ b/README.md
@@ -95,6 +95,26 @@ server container and perform the following actions within the container CLI.
    # python scripts/dummydata.py > data.dump
    ```
 
+## Testing
+
+This project uses `pytest` for testing. Tests are located in the `tests` directory.
+
+To run tests, invoke the following command in a docker terminal connected to the container:
+
+```bash
+make test
+```
+
+To generate a code coverage report to see which parts of the code are covered by the tests. This is done with the following command:
+
+```bash
+make coverage
+```
+
+This runs the tests, generates a coverage report and displays a nice HTML direcotry `htmlcov`. You can view this report
+on `http://localhost:8001/`.
+Be sure to manually refresh the page each time you run `make coverage`.
+
 ## Heroku deployment info
 
  * Register a free Heroku account here: https://signup.heroku.com/

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -10,3 +10,11 @@ services:
       - .:/app
       - /app/client/node_modules
       - /app/node_modules
+  coverage:
+    image: python:3.8
+    volumes:
+      - .:/app
+    working_dir: /app/htmlcov
+    command: python -m http.server
+    ports:
+      - "8001:8000"

--- a/scripts/coverage_html.py
+++ b/scripts/coverage_html.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+"""
+Persists the coverage report in htmlcov/ directory.
+
+This script is a workaround to explicitly save the coverage report
+and generate an html report.
+`coverage run` isn't computing a coverage report let alone generating the report.
+Correct mounts, permissions and pre-reqs are set up and the issue may be something else
+as suggested here:
+https://stackoverflow.com/a/53346768
+Manually importing, cleaning up and invoking the coverage + explicitly saving
+works as expected.
+"""
+
+from coverage import Coverage
+import pytest
+
+def build_coverage_report():
+    """Run tests and generate an html coverage report.
+
+    Equivalent to `coverage run` && `coverage html`,
+    using the default configuration files:
+    `.coveragerc` and `pytest.ini`.
+    """
+    cov = Coverage()
+    cov.erase()
+    cov.start()
+    pytest.main()
+    cov.stop()
+    cov.save()
+    cov.report()
+    cov.html_report(directory='htmlcov')
+
+if __name__ == '__main__':
+    build_coverage_report()
+


### PR DESCRIPTION
Upgrading to the latest coverage possible (7.2.0) with the latest coveralls didn’t work, so I opted to
Just leave it at the same version, which we can probably upgrade in a future PR.

Adds a development only service, exposed on port 8001 to view a coverage report:
Simplified the command to `make coverage` that will be useful to view during development:

We can now view it through a nice coveralls UI [here](https://coveralls.io/builds/66015825/source?filename=home%2Fviews%2Fweb%2Fintentionalwalk.py), or if during development :


`make coverage` and visiting `http://localhost:8001` 
<img width="807" alt="image" src="https://github.com/sfbrigade/intentional-walk-server/assets/161795448/b8f10904-5070-4cab-888d-e6feaa6601a9">

Here's the current report of our code coverage, looking quite good so far! Haven't looked too deeply into the test cases, but looks promising so far.


```
home/_init_.py	0	0	0	100%
home/admin.py	44	0	0	100%
home/apps.py	3	0	0	100%
home/models/_init_.py	7	0	0	100%
home/models/account.py	52	1	0	98%
home/models/contest.py	42	2	0	95%
home/models/dailywalk.py	39	3	0	92%
home/models/device.py	9	1	0	89%
home/models/intentionalwalk.py	43	5	0	88%
home/models/leaderboard.py	11	1	0	91%
home/models/weeklygoal.py	11	1	0	91%
home/templatetags/_init_.py	0	0	0	100%
home/templatetags/format_helpers.py	5	0	0	100%
home/urls.py	11	1	0	91%
home/utils/_init_.py	6	0	0	100%
home/utils/dates.py	7	2	0	71%
home/utils/generators.py	106	18	0	83%
home/views/_init_.py	15	0	0	100%
home/views/api/_init_.py	0	0	0	100%
home/views/api/admin.py	246	22	0	91%
home/views/api/appuser.py	128	7	0	95%
home/views/api/contest.py	14	0	0	100%
home/views/api/dailywalk.py	83	6	0	93%
home/views/api/export.py	90	2	0	98%
home/views/api/intentionalwalk.py	64	6	0	91%
home/views/api/leaderboard.py	45	4	0	91%
home/views/api/utils.py	29	8	0	72%
home/views/api/weeklygoal.py	69	2	0	97%
home/views/web/_init_.py	0	0	0	100%
home/views/web/data.py	128	19	0	85%
home/views/web/home.py	61	51	0	16%
home/views/web/intentionalwalk.py	55	43	0	22%
home/views/web/user.py	108	4	0	96%
Total	1531	209	0	86%
```


Some good targets are 
```
home/views/web/home.py	61	51	0	16%
home/views/web/intentionalwalk.py	55	43	0	22%
```
I can work on expanding these and addressing some of the test warnings.
