### PR TITLE
Modularizing admin api with serializers

### DIFF
--- a/home/tests/integration/views/api/test_admin.py
+++ b/home/tests/integration/views/api/test_admin.py
@@ -245,33 +245,25 @@ class TestAdminViews(TestCase):
         response = c.get("/api/admin/users?query=2")
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertEqual(len(data), 1) 
+        self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["name"], "User 2")
-        
+
         response = c.get("/api/admin/users?query=aintgonfindmeatall")
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertEqual(len(data), 0) 
-        
-        # sort 
+        self.assertEqual(len(data), 0)
+
+        # sort
         response = c.get("/api/admin/users?order_by=age")
         data = response.json()
         self.assertEqual(response.status_code, 200)
         ages = [user["age"] for user in data]
-        ascending_order = all(
-            a <= b for a, b in zip(
-                ages,
-                ages[1:]
-            ))
+        ascending_order = all(a <= b for a, b in zip(ages, ages[1:]))
         self.assertTrue(ascending_order)
-        
+
         response = c.get("/api/admin/users?order_by=-age")
         data = response.json()
-        self.assertEqual(
-                ages,
-                [user["age"] for user in data[::-1]]
-        )
-
+        self.assertEqual(ages, [user["age"] for user in data[::-1]])
 
     def test_get_users_by_zip(self):
         c = Client()

--- a/home/tests/unit/test_utils.py
+++ b/home/tests/unit/test_utils.py
@@ -1,0 +1,39 @@
+from django.test import TestCase
+from home.tests.integration.views.api.utils import Login
+from home.views.api.utils import require_authn
+from django.contrib.auth.models import User, AnonymousUser
+
+from django.test import TestCase, RequestFactory
+from django.views import View
+from django.http import HttpResponse
+
+class TestAuthn(TestCase):
+    def setUp(self):
+        # Create a test view that uses the require_authn decorator
+        class TestView(View):
+            @require_authn
+            def get(self, request):
+                return HttpResponse('Hello, World!')
+
+        self.view = TestView.as_view()
+        self.factory = RequestFactory()
+
+    def test_authenticated(self):
+        Login() 
+        self.user = User.objects.get(username=Login.username)
+
+        # Create a request and authenticate the user
+        request = self.factory.get('/')
+        request.user = self.user 
+
+        response = self.view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode(), 'Hello, World!')
+    
+    def test_unauthenticated(self):
+        # Create a request and don't authenticate the user
+        request = self.factory.get('/')
+        request.user = AnonymousUser()
+
+        response = self.view(request)
+        self.assertEqual(response.status_code, 401)

--- a/home/tests/unit/test_utils.py
+++ b/home/tests/unit/test_utils.py
@@ -1,4 +1,3 @@
-from django.test import TestCase
 from home.tests.integration.views.api.utils import Login
 from home.views.api.utils import require_authn
 from django.contrib.auth.models import User, AnonymousUser
@@ -7,32 +6,33 @@ from django.test import TestCase, RequestFactory
 from django.views import View
 from django.http import HttpResponse
 
+
 class TestAuthn(TestCase):
     def setUp(self):
         # Create a test view that uses the require_authn decorator
         class TestView(View):
             @require_authn
             def get(self, request):
-                return HttpResponse('Hello, World!')
+                return HttpResponse("Hello, World!")
 
         self.view = TestView.as_view()
         self.factory = RequestFactory()
 
     def test_authenticated(self):
-        Login() 
+        Login()
         self.user = User.objects.get(username=Login.username)
 
         # Create a request and authenticate the user
-        request = self.factory.get('/')
-        request.user = self.user 
+        request = self.factory.get("/")
+        request.user = self.user
 
         response = self.view(request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode(), 'Hello, World!')
-    
+        self.assertEqual(response.content.decode(), "Hello, World!")
+
     def test_unauthenticated(self):
         # Create a request and don't authenticate the user
-        request = self.factory.get('/')
+        request = self.factory.get("/")
         request.user = AnonymousUser()
 
         response = self.view(request)

--- a/home/views/api/admin.py
+++ b/home/views/api/admin.py
@@ -17,8 +17,12 @@ from django.http import HttpResponse, JsonResponse
 from django.views import View
 
 from home.models import Account, Contest, DailyWalk
-from home.views.api.serializers.request_serializers import GetUsersReqSerializer
-from home.views.api.serializers.response_serializers import GetUsersRespSerializer
+from home.views.api.serializers.request_serializers import (
+    GetUsersReqSerializer,
+)
+from home.views.api.serializers.response_serializers import (
+    GetUsersRespSerializer,
+)
 
 from .utils import paginate, require_authn
 
@@ -300,17 +304,17 @@ class AdminUsersView(View):
         if not serializer.is_valid():
             return JsonResponse(serializer.errors, status=422)
 
-        validated = serializer.validated_data 
-        
+        validated = serializer.validated_data
+
         contest_id = validated["contest_id"]
         filters = validated["filters"]
         order_by = validated["order_by"]
         page = validated["page"]
         per_page = validated["per_page"]
-        
+
         annotate = validated["annotate"]
-        intentionalwalk_annotate= validated["intentionalwalk_annotate"]
-        
+        intentionalwalk_annotate = validated["intentionalwalk_annotate"]
+
         query = (
             Account.objects.filter(filters)
             .values("id", "name", "email", "age", "zip", "created")
@@ -325,24 +329,24 @@ class AdminUsersView(View):
             .annotate(**intentionalwalk_annotate)
             .order_by(*order_by)
         )
+
         def update_user_dto(dto, iw_stats):
             dto.update(iw_stats)
             # at this point, we have enough info to determine if user is "active"
             if contest_id:
-                dto["is_active"] = (
-                    dto["dw_count"] > 0
-                    or dto["iw_count"] > 0
-                )
-            return dto 
+                dto["is_active"] = dto["dw_count"] > 0 or dto["iw_count"] > 0
+            return dto
 
-        result_dto = [update_user_dto(dto, iw_stat) for dto, iw_stat in zip(query, iw_query)]
+        result_dto = [
+            update_user_dto(dto, iw_stat)
+            for dto, iw_stat in zip(query, iw_query)
+        ]
         resp = GetUsersRespSerializer(result_dto, many=True)
         response = JsonResponse(resp.data, safe=False)
         if links:
             response.headers["Link"] = links
 
         return response
-    
 
 
 class AdminUsersByZipView(View):

--- a/home/views/api/admin.py
+++ b/home/views/api/admin.py
@@ -6,11 +6,8 @@ from dateutil import parser
 
 from django.db import connection
 from django.db.models import (
-    BooleanField,
     CharField,
     Count,
-    ExpressionWrapper,
-    F,
     Q,
     Sum,
     Value,
@@ -20,8 +17,10 @@ from django.http import HttpResponse, JsonResponse
 from django.views import View
 
 from home.models import Account, Contest, DailyWalk
+from home.views.api.serializers.request_serializers import GetUsersReqSerializer
+from home.views.api.serializers.response_serializers import GetUsersRespSerializer
 
-from .utils import paginate
+from .utils import paginate, require_authn
 
 logger = logging.getLogger(__name__)
 
@@ -295,125 +294,55 @@ class AdminContestsView(View):
 class AdminUsersView(View):
     http_method_names = ["get"]
 
+    @require_authn
     def get(self, request, *args, **kwargs):
-        if request.user.is_authenticated:
-            values = ["id", "name", "email", "age", "zip", "created"]
-            order_by = request.GET.get("order_by", "name")
-            page = int(request.GET.get("page", "1"))
-            per_page = 25
+        serializer = GetUsersReqSerializer(data=request.GET)
+        if not serializer.is_valid():
+            return JsonResponse(serializer.errors, status=422)
 
-            # filter and annotate based on contest_id
-            filters = None
-            annotate = None
-            contest_id = request.GET.get("contest_id", None)
-            intentionalwalk_filter = None
+        validated = serializer.validated_data 
+        
+        contest_id = validated["contest_id"]
+        filters = validated["filters"]
+        order_by = validated["order_by"]
+        page = validated["page"]
+        per_page = validated["per_page"]
+        
+        annotate = validated["annotate"]
+        intentionalwalk_annotate= validated["intentionalwalk_annotate"]
+        
+        query = (
+            Account.objects.filter(filters)
+            .values("id", "name", "email", "age", "zip", "created")
+            .annotate(**annotate)
+            .order_by(*order_by)
+        )
+        query, links = paginate(request, query, page, per_page)
+
+        iw_query = (
+            Account.objects.filter(id__in=(row["id"] for row in query))
+            .values("id")
+            .annotate(**intentionalwalk_annotate)
+            .order_by(*order_by)
+        )
+        def update_user_dto(dto, iw_stats):
+            dto.update(iw_stats)
+            # at this point, we have enough info to determine if user is "active"
             if contest_id:
-                filters = Q(contests__contest_id=contest_id)
-                contest = Contest.objects.get(pk=contest_id)
-                dailywalk_filter = Q(
-                    dailywalk__date__range=(contest.start, contest.end)
+                dto["is_active"] = (
+                    dto["dw_count"] > 0
+                    or dto["iw_count"] > 0
                 )
-                intentionalwalk_filter = Q(
-                    intentionalwalk__start__gte=contest.start,
-                    intentionalwalk__start__lt=contest.end + timedelta(days=1),
-                )
-                annotate = {
-                    "is_new": ExpressionWrapper(
-                        Q(
-                            created__gte=contest.start_promo,
-                            created__lt=contest.end + timedelta(days=1),
-                        ),
-                        output_field=BooleanField(),
-                    ),
-                    "dw_count": Count("dailywalk", filter=dailywalk_filter),
-                    "dw_steps": Sum(
-                        "dailywalk__steps", filter=dailywalk_filter
-                    ),
-                    "dw_distance": Sum(
-                        "dailywalk__distance", filter=dailywalk_filter
-                    ),
-                }
-            else:
-                filters = Q()
-                annotate = {
-                    "dw_count": Count("dailywalk"),
-                    "dw_steps": Sum("dailywalk__steps"),
-                    "dw_distance": Sum("dailywalk__distance"),
-                }
-                intentionalwalk_filter = Q()
+            return dto 
 
-            # filter to show users vs testers
-            filters = filters & Q(
-                is_tester=request.GET.get("is_tester", None) == "true"
-            )
+        result_dto = [update_user_dto(dto, iw_stat) for dto, iw_stat in zip(query, iw_query)]
+        resp = GetUsersRespSerializer(result_dto, many=True)
+        response = JsonResponse(resp.data, safe=False)
+        if links:
+            response.headers["Link"] = links
 
-            # filter by search query
-            query = request.GET.get("query", None)
-            if query:
-                filters = filters & Q(
-                    Q(name__icontains=query) | Q(email__icontains=query)
-                )
-
-            # set ordering
-            add_name = False
-            if order_by.startswith("-"):
-                add_name = order_by[1:] != "name"
-                order_by = [F(order_by[1:]).desc(nulls_last=True)]
-            else:
-                add_name = order_by != "name"
-                order_by = [F(order_by).asc(nulls_first=False)]
-            if add_name:
-                order_by.append("name")
-
-            # perform query!
-            results = (
-                Account.objects.filter(filters)
-                .values(*values)
-                .annotate(**annotate)
-                .order_by(*order_by)
-            )
-            (results, links) = paginate(request, results, page, per_page)
-            results = list(results)
-
-            # now query for and add in recorded IntentionalWalk stats
-            ids = [row["id"] for row in results]
-            iw_results = (
-                Account.objects.filter(id__in=ids)
-                .values("id")
-                .annotate(
-                    iw_count=Count(
-                        "intentionalwalk", filter=intentionalwalk_filter
-                    ),
-                    iw_steps=Sum(
-                        "intentionalwalk__steps", filter=intentionalwalk_filter
-                    ),
-                    iw_distance=Sum(
-                        "intentionalwalk__distance",
-                        filter=intentionalwalk_filter,
-                    ),
-                    iw_time=Sum(
-                        "intentionalwalk__walk_time",
-                        filter=intentionalwalk_filter,
-                    ),
-                )
-                .order_by(*order_by)
-            )
-            for i, row in enumerate(iw_results):
-                results[i].update(row)
-                # at this point, we have enough info to determine if user is "active"
-                if contest_id:
-                    results[i]["is_active"] = (
-                        results[i]["dw_count"] > 0
-                        or results[i]["iw_count"] > 0
-                    )
-
-            response = JsonResponse(list(results), safe=False)
-            if links:
-                response.headers["Link"] = links
-
-            return response
-        else:
-            return HttpResponse(status=401)
+        return response
+    
 
 
 class AdminUsersByZipView(View):

--- a/home/views/api/serializers/request_serializers.py
+++ b/home/views/api/serializers/request_serializers.py
@@ -1,0 +1,138 @@
+"""
+This module contains serializers that are used for parsing and validating request data.
+
+Each serializer in this module corresponds to a specific API endpoint. The serializer's
+`validate` method is responsible for validating the incoming request data and preparing
+it for further processing.
+"""
+from rest_framework import serializers 
+from datetime import timedelta
+from home.models import Contest
+from django.db.models import (
+    BooleanField,
+    Count,
+    ExpressionWrapper,
+    F,
+    Q,
+    Sum,
+)
+
+class GetUsersReqSerializer(serializers.Serializer):
+    contest_id = serializers.CharField(
+        required=False,
+        help_text="The ID of the contest to filter by. Providing this also will add additional metrics related to te contest."
+    )
+    # If true, will only return tester accounts.
+    is_tester = serializers.BooleanField(
+        required=False,
+        help_text="If true, will only return tester accounts."                                  
+    )
+    # Choices are: age, contests, created, dailywalk, device, email, gender, gender_other, id, intentionalwalk, is_latino, is_sf_resident, is_tester, 
+    # iw_count, iw_distance, iw_steps, iw_time, leaderboard, name, race, race_other, sexual_orien, sexual_orien_other, updated, weeklygoal, zip
+    # TODO: Can move this to the choices field tuple
+    # which will allow some tools to auto-pick up.
+    order_by = serializers.CharField(
+        required=False,
+        help_text="The field to order the results by. Prefix with '-' to order in descending order. The secondary sort and default sort will be lexicographically, the 'name'."
+    )
+    page = serializers.IntegerField(
+        required=False,
+        help_text="The page number to return. Defaults to 1.",
+        default=1,
+    )
+    query = serializers.CharField(
+        required=False,
+        help_text="Query string to filter for containment in the name or email."
+    )
+
+    def validate(self, data):
+        """Validates and prepares the incoming request data.
+
+        Converts the request params into FilterSet params and annotations.
+        """
+        contest_id = data.get("contest_id")
+        is_tester = data.get("is_tester")
+        order_by = data.get("order_by")
+        page = data.get("page") or 1
+        per_page = 25
+        query = data.get("query")
+
+        # filter and annotate based on contest_id
+        filters, annotate, intentionalwalk_filter = None, None, None
+        if contest_id:
+            contest = Contest.objects.get(pk=contest_id)
+            dailywalk_filter = Q(
+                dailywalk__date__range=(contest.start, contest.end)
+            )
+
+            filters = Q(contests__contest_id=contest_id)
+            annotate = {
+                "is_new": ExpressionWrapper(
+                    Q(
+                        created__gte=contest.start_promo,
+                        created__lt=contest.end + timedelta(days=1),
+                    ),
+                    output_field=BooleanField(),
+                ),
+                "dw_count": Count("dailywalk", filter=dailywalk_filter),
+                "dw_steps": Sum("dailywalk__steps", filter=dailywalk_filter),
+                "dw_distance": Sum(
+                    "dailywalk__distance", filter=dailywalk_filter
+                ),
+            }
+            intentionalwalk_filter = Q(
+                intentionalwalk__start__gte=contest.start,
+                intentionalwalk__start__lt=contest.end + timedelta(days=1),
+            )
+        else:
+            filters = Q()
+            annotate = {
+                "dw_count": Count("dailywalk"),
+                "dw_steps": Sum("dailywalk__steps"),
+                "dw_distance": Sum("dailywalk__distance"),
+            }
+            intentionalwalk_filter = Q()
+
+        intentionalwalk_annotate = {
+            "iw_count": Count(
+                "intentionalwalk", filter=intentionalwalk_filter
+            ),
+            "iw_steps": Sum(
+                "intentionalwalk__steps", filter=intentionalwalk_filter
+            ),
+            "iw_distance": Sum(
+                "intentionalwalk__distance", filter=intentionalwalk_filter
+            ),
+            "iw_time": Sum(
+                "intentionalwalk__walk_time", filter=intentionalwalk_filter
+            ),
+        }  
+        
+        # filter to show users vs testers
+        filters &= Q(is_tester=is_tester)
+
+        # filter by search query
+        if query:
+            filters &= Q(Q(name__icontains=query) | Q(email__icontains=query))
+
+        # set ordering
+        order = []
+        if order_by:
+            desc = order_by.startswith("-")
+            field = F(order_by[1:] if desc else order_by)
+            order.append(
+                field.desc(nulls_last=True)
+                if desc
+                else field.asc(nulls_first=False)
+            )
+        order.append(F("name"))
+
+        return {
+            "annotate": annotate,
+            "intentionalwalk_annotate": intentionalwalk_annotate,
+            "contest_id": contest_id,
+            "filters": filters,
+            "order_by": order,
+            "page": page,
+            "per_page": per_page,
+        }

--- a/home/views/api/serializers/request_serializers.py
+++ b/home/views/api/serializers/request_serializers.py
@@ -5,7 +5,8 @@ Each serializer in this module corresponds to a specific API endpoint. The seria
 `validate` method is responsible for validating the incoming request data and preparing
 it for further processing.
 """
-from rest_framework import serializers 
+
+from rest_framework import serializers
 from datetime import timedelta
 from home.models import Contest
 from django.db.models import (
@@ -17,23 +18,27 @@ from django.db.models import (
     Sum,
 )
 
+
 class GetUsersReqSerializer(serializers.Serializer):
     contest_id = serializers.CharField(
         required=False,
-        help_text="The ID of the contest to filter by. Providing this also will add additional metrics related to te contest."
+        help_text="The ID of the contest to filter by."
+        + "Providing this also will add additional metrics related to te contest.",
     )
     # If true, will only return tester accounts.
     is_tester = serializers.BooleanField(
-        required=False,
-        help_text="If true, will only return tester accounts."                                  
+        required=False, help_text="If true, will only return tester accounts."
     )
-    # Choices are: age, contests, created, dailywalk, device, email, gender, gender_other, id, intentionalwalk, is_latino, is_sf_resident, is_tester, 
-    # iw_count, iw_distance, iw_steps, iw_time, leaderboard, name, race, race_other, sexual_orien, sexual_orien_other, updated, weeklygoal, zip
-    # TODO: Can move this to the choices field tuple
+    # Choices are: age, contests, created, dailywalk, device, email, gender, gender_other, id,
+    # intentionalwalk,  is_latino, is_sf_resident, is_tester, iw_count, iw_distance, iw_steps,
+    # iw_time, leaderboard, name, race, race_other, sexual_orien, sexual_orien_other, updated,
+    # weeklygoal, zip.
+    # TODO: Can move this to the choices field tuple.
     # which will allow some tools to auto-pick up.
     order_by = serializers.CharField(
         required=False,
-        help_text="The field to order the results by. Prefix with '-' to order in descending order. The secondary sort and default sort will be lexicographically, the 'name'."
+        help_text="The field to order the results by. Prefix with '-' to order in descending order."
+        + "The secondary sort and default sort will be lexicographically, the 'name'.",
     )
     page = serializers.IntegerField(
         required=False,
@@ -42,7 +47,7 @@ class GetUsersReqSerializer(serializers.Serializer):
     )
     query = serializers.CharField(
         required=False,
-        help_text="Query string to filter for containment in the name or email."
+        help_text="Query string to filter for containment in the name or email.",
     )
 
     def validate(self, data):
@@ -106,8 +111,8 @@ class GetUsersReqSerializer(serializers.Serializer):
             "iw_time": Sum(
                 "intentionalwalk__walk_time", filter=intentionalwalk_filter
             ),
-        }  
-        
+        }
+
         # filter to show users vs testers
         filters &= Q(is_tester=is_tester)
 

--- a/home/views/api/serializers/response_serializers.py
+++ b/home/views/api/serializers/response_serializers.py
@@ -1,0 +1,36 @@
+"""
+This module contains serializers that are used for formatting the response data.
+
+Each serializer in this module corresponds to a specific API endpoint.
+These serve to map internal Python data types
+to JSON-compatible data types that can be sent in the HTTP response,
+and to clearly document the structure of the response data.
+"""
+from rest_framework import serializers
+from home.models import Account 
+
+class GetUsersRespSerializer(serializers.ModelSerializer):
+    # Daily walk metrics.
+    dw_count = serializers.IntegerField()
+    dw_steps = serializers.IntegerField()
+    dw_distance = serializers.FloatField()
+
+    # Contest-id specific metrics. These only appear if contest_id 
+    # was specified in the query URL.
+    iw_count = serializers.IntegerField(required=False)
+    iw_steps = serializers.IntegerField(required=False)
+    iw_distance = serializers.FloatField(required=False)
+    iw_time = serializers.IntegerField(required=False)
+    
+    # True if the user's Account was created within the contest period.
+    is_new= serializers.BooleanField(
+        required=False,
+    )
+    # True is the user has walked at least one step.
+    is_active = serializers.BooleanField(
+        required=False,
+    )
+
+    class Meta:
+        model = Account 
+        fields = '__all__'

--- a/home/views/api/serializers/response_serializers.py
+++ b/home/views/api/serializers/response_serializers.py
@@ -7,7 +7,8 @@ to JSON-compatible data types that can be sent in the HTTP response,
 and to clearly document the structure of the response data.
 """
 from rest_framework import serializers
-from home.models import Account 
+from home.models import Account
+
 
 class GetUsersRespSerializer(serializers.ModelSerializer):
     # Daily walk metrics.
@@ -15,15 +16,15 @@ class GetUsersRespSerializer(serializers.ModelSerializer):
     dw_steps = serializers.IntegerField()
     dw_distance = serializers.FloatField()
 
-    # Contest-id specific metrics. These only appear if contest_id 
+    # Contest-id specific metrics. These only appear if contest_id
     # was specified in the query URL.
     iw_count = serializers.IntegerField(required=False)
     iw_steps = serializers.IntegerField(required=False)
     iw_distance = serializers.FloatField(required=False)
     iw_time = serializers.IntegerField(required=False)
-    
+
     # True if the user's Account was created within the contest period.
-    is_new= serializers.BooleanField(
+    is_new = serializers.BooleanField(
         required=False,
     )
     # True is the user has walked at least one step.
@@ -32,5 +33,5 @@ class GetUsersRespSerializer(serializers.ModelSerializer):
     )
 
     class Meta:
-        model = Account 
-        fields = '__all__'
+        model = Account
+        fields = "__all__"

--- a/home/views/api/utils.py
+++ b/home/views/api/utils.py
@@ -2,7 +2,8 @@ import functools
 from math import ceil
 from typing import Any, Dict, List, Callable
 from django.http import HttpResponse
-from django.views import View 
+from django.views import View
+
 
 def paginate(request, results, page, per_page):
     count = results.count()
@@ -61,6 +62,7 @@ def validate_request_json(
 
     return response
 
+
 def require_authn(func: Callable[[View, Any, Any], HttpResponse]):
     """Decorator for Django View methods to require authn.
 
@@ -69,7 +71,7 @@ def require_authn(func: Callable[[View, Any, Any], HttpResponse]):
 
     Parameters
     ----------
-    func: 
+    func:
         The View method to decorate.
 
     Returns
@@ -77,9 +79,11 @@ def require_authn(func: Callable[[View, Any, Any], HttpResponse]):
         The decorated method.
 
     """
+
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
         if not self.request.user.is_authenticated:
             return HttpResponse(status=401)
         return func(self, *args, **kwargs)
+
     return wrapper

--- a/poetry.lock
+++ b/poetry.lock
@@ -307,6 +307,21 @@ reference = "HEAD"
 resolved_reference = "5969124d3da75a5ce1e5b84806f2fd2f8b7b532e"
 
 [[package]]
+name = "djangorestframework"
+version = "3.14.0"
+description = "Web APIs for Django, made easy."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "djangorestframework-3.14.0-py3-none-any.whl", hash = "sha256:eb63f58c9f218e1a7d064d17a70751f528ed4e1d35547fdade9aaf4cd103fd08"},
+    {file = "djangorestframework-3.14.0.tar.gz", hash = "sha256:579a333e6256b09489cbe0a067e66abe55c6595d8926be6b99423786334350c8"},
+]
+
+[package.dependencies]
+django = ">=3.0"
+pytz = "*"
+
+[[package]]
 name = "docopt"
 version = "0.6.2"
 description = "Pythonic argument parser, that will make you smile"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ django-postgres-setfield = {git = "https://github.com/benperlman/django-postgres
 black = "^22.8.0"
 flake8 = "^5.0.4"
 autoflake = "^1.5.3"
+djangorestframework = "^3.14.0"
 
 [tool.poetry.dev-dependencies]
 freezegun = "^1.1.0"


### PR DESCRIPTION
This patch modularizes a controller using django's rest serializers, refactoring`GET /api/admin/users` as  example.


Modularizing with serializers has several benefits, that I think could be very useful for us and future maintainers of this repo (they will appreciate it 😀 , and it will **significantly** help with onboarding)

- Code is much cleaner and easier to read. It's much easier to follow and clearly see the query params and the response.
- It provides automatic error messages if the data is invalid.
- It allows us to reuse the same validation logic in multiple views.
- It integrates well with Django REST Framework's other features, like automatic API documentation. We can easily generate swagger docs API

Some cons are much more code, and more indirection, but as the app is small, I think this isn't too bad. Let me know what you guys think!

Expanded the tests and refactored some pieces of code. 
Django's query set is lazily fetched and only gets enacted once you iterate on them, so it's good to use generator comprehensions as opposed to just instantly casting them as lists or using plain for loops, which are slow in python.

These comprehensions are not only more readable and more performant but are idiomatic and retain the laziness.