### PR TITLE
Poetry CI Upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,10 @@ jobs:
           name: Install Poetry
           command: |
             curl -sSL https://install.python-poetry.org | python3 - --version 1.2.2
+      - run:
+          name: Check valid poetry.lock
+          command: |
+            poetry check -vvv
       - restore_cache:
           keys:
             - deps-{{ checksum "poetry.lock" }}
@@ -25,7 +29,7 @@ jobs:
           name: Install Dependencies
           command: |
             poetry config virtualenvs.create false
-            poetry install
+            poetry install -vvv
       - save_cache:
           key: deps-{{ checksum "poetry.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: Install Poetry
           command: |
-            curl -sSL https://install.python-poetry.org | python3 - --version 1.2.2
+            curl -sSL https://install.python-poetry.org | python3 - --version 1.8.2
       - run:
           name: Check valid poetry.lock
           command: |

--- a/poetry.lock
+++ b/poetry.lock
@@ -824,4 +824,4 @@ brotli = ["Brotli"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "obviously-invalid-content-hash"
+content-hash = "5c86a2e78c42307fdf84a73f8b7b3f0ce6097ec5d4a49457a584d42c00f170b8"

--- a/poetry.lock
+++ b/poetry.lock
@@ -824,4 +824,4 @@ brotli = ["Brotli"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "3beacfa2e209c4261b20b99c397f5552d098b06912d690eace55590ffa5acdba"
+content-hash = "obviously-invalid-content-hash"


### PR DESCRIPTION
Our poetry version was upgraded from 1.5.1 to 1.8.2 after this [patch](https://github.com/sfbrigade/intentional-walk-server/pull/175/files#diff-f53a023eedfa3fbf2925ec7dc76eecdc954ea94b7e47065393dbad519613dc89). This [patch](https://github.com/sfbrigade/intentional-walk-server/pull/174) introduced a new dependency without updating the `content-hash` field of the poetry lock.

The current version of poetry we are using for CI (1.2.2) silently lets this pass [through](https://github.com/sfbrigade/intentional-walk-server/pull/174).

Upgrading for 1.8.2 prevents invalid `poetry.lock` from passing CI, and invoke `poetry lock --no-update` to correct the content-hash for the lock file.

