### PR TITLE
Sync CI postgres image version with Docker to support Django 4.X

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,9 @@ jobs:
         environment:
           DATABASE_URL: "postgresql://postgres@localhost/webtool"
           SECRET_KEY: "secretkey"
-      - image: cimg/postgres:11.17
+        # This image MUST be in-sync with our Docker image for production
+        # TODO: Use the same image as our dockerfile to test build instead of this
+      - image: cimg/postgres:12.8
         environment: POSTGRES_HOST_AUTH_METHOD=trust
     steps:
       - checkout
@@ -41,7 +43,11 @@ jobs:
             poetry run flake8 --count home server manage.py
       - run:
           name: Run Pytest, report coverage
+          # make test and make coverage are redundant,
+          # but make coverage actually doesn't fail the build if it fails; it just reports a lower
+          # coverage percentage for failing short, but "succeeds"
           command: |
+            make test
             make coverage
             poetry run coveralls
 workflows:

--- a/home/tests/integration/views/api/test_admin.py
+++ b/home/tests/integration/views/api/test_admin.py
@@ -242,7 +242,7 @@ class TestAdminViews(TestCase):
         self.assertEqual(len(data), 1)  # 1 tester
 
         # query
-        response = c.get("/api/admin/users?query=2")
+        response = c.get("/api/admin/users?query=User 2")
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data), 1)


### PR DESCRIPTION
Recently, we've been getting some strange >37% code coverage through  [coveralls](https://coveralls.io/jobs/138742056) while running locally we should be having ~88% code coverage.

The reason for this is because `pytest coverage` was actually failing. The error message was hard to find but it was hidden in the `coveralls` report here on [line 228](https://app.circleci.com/pipelines/github/sfbrigade/intentional-walk-server/535/workflows/fde4abc0-5313-41bb-9168-5d686e531d45/jobs/551)
```
     )
E           django.db.utils.NotSupportedError: PostgreSQL 12 or later is required (found 11.17).

../.pyenv/versions/3.11.4/lib/python3.11/site-packages/django/db/backends/base/base.py:214: NotSupportedError
```

Coverage reporting doesn't actually error out the CI, so errors fail silently - to fix this we add a `make test`, which WILL fail.

We also upgrade our CI to match the version in our Docker. It might be better to just use the Docker image in the CI (in a later PR).

Also, our random generated tests don't set a seed for RNG for deterministic tests, so if the randomly generated data creates a field with "2", it'll be captured in the test. 
It's changed here to be more specific, but the other PRs fix the RNG to a seed.


