### PR TITLE
Actually use our Dockerfile for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,14 +34,14 @@ jobs:
       - run:
           name: Lint code with Flake8
           command: |
-            docker exec server bash -c "poetry run flake8 --count ."
+            docker-compose -p iwalk exec server bash -c "poetry run flake8 --count ."
       - run:
           name: Run Pytest, report coverage
           # make test and make coverage are redundant,
           # but make coverage actually doesn't fail the build if it fails; it just reports a lower
           # coverage percentage for failing short, but "succeeds"
           command: |
-            docker exec server bash -c "
+            docker-compose -p iwalk exec -e COVERALLS_REPO_TOKEN server bash -c "
               make test
               make coverage
               poetry run coveralls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,44 +12,32 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true 
       - run:
-          name: Build Docker image
+          name: Copy example.env to .env
           command: |
-            docker build -t iwalk .
+            cp example.env .env      
       - run:
           name: Run Docker image
           command: |
-            docker run -d --name iwalk iwalk &&  docker logs iwalk && docker exec iwalk bash -c "curl -sSL https://install.python-poetry.org | python3 - --version 1.8.2"
-      - run:
-          name: Install Poetry
-          command: |
-            docker exec iwalk bash -c "curl -sSL https://install.python-poetry.org | python3 - --version 1.8.2"
+            docker-compose -p iwalk -f docker-compose.yml -f docker-compose.override.yml up -d
       - run:
           name: Check Poetry
           command: |
-            docker exec iwalk bash -c "poetry check -vvv"
-      - run:
-          name: Configure Poetry
-          command: |
-            docker exec iwalk bash -c "poetry config virtualenvs.create false"
-      - run:
-          name: Install dependencies
-          command: |
-            docker exec iwalk bash -c "poetry install -vvv"
+            docker-compose -p iwalk exec server bash -c "poetry check -vvv"
       - run:
           name: Check code formatting with Black
           command: |
-            docker exec iwalk bash -c "poetry run black --check ."
+            docker-compose -p iwalk exec server bash -c "black --check ."
       - run:
           name: Lint code with Flake8
           command: |
-            docker exec iwalk bash -c "poetry run flake8 --count ."
+            docker exec server bash -c "poetry run flake8 --count ."
       - run:
           name: Run Pytest, report coverage
           # make test and make coverage are redundant,
           # but make coverage actually doesn't fail the build if it fails; it just reports a lower
           # coverage percentage for failing short, but "succeeds"
           command: |
-            docker exec iwalk bash -c "
+            docker exec server bash -c "
               make test
               make coverage
               poetry run coveralls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,8 @@ jobs:
       - image: cimg/base:edge
     steps:
       - checkout
-      - setup_remote_docker:
+      - machine:
+          image: ubuntu-2004:202106-01
           docker_layer_caching: true 
       - run:
           name: Copy example.env to .env
@@ -22,7 +23,7 @@ jobs:
       - run:
           name: Check Poetry
           command: |
-            docker-compose -p iwalk exec server bash -c "poetry check -vvv"
+            docker-compose -p iwalk exec iwalk-server-1 bash -c "poetry check -vvv"
       - run:
           name: Check code formatting with Black
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,14 @@ jobs:
           command: |
             docker-compose -p iwalk -f docker-compose.yml -f docker-compose.override.yml up -d
       - run:
+          name: LOGS 
+          command: |
+            echo "showing logs..."
+            docker-compose -p iwalk logs
+      - run:
           name: Check Poetry
           command: |
-            docker-compose -p iwalk exec iwalk-server-1 bash -c "poetry check -vvv"
+            docker-compose -p iwalk exec server bash -c "poetry check -vvv"
       - run:
           name: Check code formatting with Black
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,50 +6,54 @@ orbs:
 jobs:
   build-and-test:
     docker:
-      - image: cimg/python:3.11.4
-        environment:
-          DATABASE_URL: "postgresql://postgres@localhost/webtool"
-          SECRET_KEY: "secretkey"
-        # This image MUST be in-sync with our Docker image for production
-        # TODO: Use the same image as our dockerfile to test build instead of this
-      - image: cimg/postgres:12.8
-        environment: POSTGRES_HOST_AUTH_METHOD=trust
+      - image: cimg/base:edge
     steps:
       - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true 
+      - run:
+          name: Build Docker image
+          command: |
+            docker build -t iwalk .
+      - run:
+          name: Run Docker image
+          command: |
+            docker run -d --name iwalk iwalk &&  docker logs iwalk && docker exec iwalk bash -c "curl -sSL https://install.python-poetry.org | python3 - --version 1.8.2"
       - run:
           name: Install Poetry
           command: |
-            curl -sSL https://install.python-poetry.org | python3 - --version 1.8.2
+            docker exec iwalk bash -c "curl -sSL https://install.python-poetry.org | python3 - --version 1.8.2"
       - run:
-          name: Check valid poetry.lock
+          name: Check Poetry
           command: |
-            poetry check -vvv
-      - restore_cache:
-          keys:
-            - deps-{{ checksum "poetry.lock" }}
+            docker exec iwalk bash -c "poetry check -vvv"
       - run:
-          name: Install Dependencies
+          name: Configure Poetry
           command: |
-            poetry config virtualenvs.create false
-            poetry install -vvv
-      - save_cache:
-          key: deps-{{ checksum "poetry.lock" }}
-          paths:
-            - /home/circleci/.cache/pypoetry/virtualenvs
+            docker exec iwalk bash -c "poetry config virtualenvs.create false"
       - run:
-          name: Run linter checks
+          name: Install dependencies
           command: |
-            poetry run black --check .
-            poetry run flake8 --count . 
+            docker exec iwalk bash -c "poetry install -vvv"
+      - run:
+          name: Check code formatting with Black
+          command: |
+            docker exec iwalk bash -c "poetry run black --check ."
+      - run:
+          name: Lint code with Flake8
+          command: |
+            docker exec iwalk bash -c "poetry run flake8 --count ."
       - run:
           name: Run Pytest, report coverage
           # make test and make coverage are redundant,
           # but make coverage actually doesn't fail the build if it fails; it just reports a lower
           # coverage percentage for failing short, but "succeeds"
           command: |
-            make test
-            make coverage
-            poetry run coveralls
+            docker exec iwalk bash -c "
+              make test
+              make coverage
+              poetry run coveralls
+            "
 workflows:
   main:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,11 @@ orbs:
 
 jobs:
   build-and-test:
-    docker:
-      - image: cimg/base:edge
+    machine:
+      image: ubuntu-2004:current 
+      docker_layer_caching: true 
     steps:
       - checkout
-      - machine:
-          image: ubuntu-2004:202106-01
-          docker_layer_caching: true 
       - run:
           name: Copy example.env to .env
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,20 +6,20 @@ orbs:
 jobs:
   build-and-test:
     machine:
-      image: ubuntu-2004:current 
-      docker_layer_caching: true 
+      image: ubuntu-2004:current
+      docker_layer_caching: true
     steps:
       - checkout
       - run:
           name: Copy example.env to .env
           command: |
-            cp example.env .env      
+            cp example.env .env
       - run:
           name: Run Docker image
           command: |
             docker-compose -p iwalk -f docker-compose.yml -f docker-compose.override.yml up -d
       - run:
-          name: LOGS 
+          name: LOGS
           command: |
             echo "showing logs..."
             docker-compose -p iwalk logs
@@ -40,8 +40,15 @@ jobs:
           # make test and make coverage are redundant,
           # but make coverage actually doesn't fail the build if it fails; it just reports a lower
           # coverage percentage for failing short, but "succeeds"
+          # We are not at risk:
+          # As we are
+          # Building this in a container on a remote ci server,
+          # we are not at risk of the following:
+          # https://stackoverflow.com/a/73100228
+          # git config --global --add safe.directory /app
           command: |
             docker-compose -p iwalk exec -e COVERALLS_REPO_TOKEN server bash -c "
+              git config --global --add safe.directory /app 
               make test
               make coverage
               poetry run coveralls

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   server:
+    image: server
     command: bash -l -c "bin/init; nf start -j Procfile.dev"
     environment:
       - PORT=3000

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   server:
-    image: server
+    container_name: server
     command: bash -l -c "bin/init; nf start -j Procfile.dev"
     environment:
       - PORT=3000


### PR DESCRIPTION
# Problem
One of the issues we had with CI was that our CI wasn't necessarily in-sync with our actual build.
We saw this issue twice, once with a Django upgrade that no longer worked with postgres v12 and under, (CI was still on 11.XX) and a second time with forgetting to run a `requirements.txt` update after installing with poetry.

# Resolution
We can resolve this and prevent this issue by just _actually_ using our `docker-compose` set up and running full CI on it.

CircleCI already builds for us using custom pre-built images they've provided, but we can just use our builds and have it run [it](https://circleci.com/docs/building-docker-images/). CircleCI base images provide `docker` and `docker-compose`already pre-installed.

I opted to just go for the [machine executor](https://circleci.com/docs/building-docker-images/#run-docker-commands-using-the-machine-executor) over our previous circle CI convenience image with the [remote docker ](https://circleci.com/docs/docker-layer-caching/#remote-docker-environment) since the remote version will have some workarounds we'll need to do if ever we need to set up volumes or port fowarding: https://circleci.com/docs/docker-compose/#using-docker-compose-with-docker-executor (not that we need this in CI).

