### PR TITLE
Update proxy to target to 127.0.0.1:8000

### DIFF
--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -4,7 +4,7 @@ module.exports = function (app) {
   app.use(
     ["/admin", "/api", "/static/home"],
     createProxyMiddleware({
-      target: "http://localhost:8000",
+      target: "http://127.0.0.1:8000",
       changeOrigin: true,
     })
   );

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -15,9 +15,9 @@ services:
     volumes:
       - .:/app
     working_dir: /app/htmlcov
-    command: python -m http.server
+    command: python -m http.server 8001
     ports:
-      - "8001:8000"
+      - "8001:8001"
   db:
     image: postgres:12
     ports:

--- a/example.env
+++ b/example.env
@@ -1,4 +1,4 @@
-ALLOWED_HOSTS=localhost
+ALLOWED_HOSTS=localhost,127.0.0.1
 DATABASE_URL=postgresql://postgres@db/iwalk
 DEBUG=1
 SECRET_KEY=q!=ahgtraat*k4ytuniq)0892h7j5^2koqp55mh6p18$4344ks


### PR DESCRIPTION
Resolve an `ERRCONNREFUSED` when trying to proxy localhost:3000 to localhost:8000.

This was previously okay before but with the Node 17, this is no longer the case. I don't actually recall any Node upgrades.
> Node.js 17+ no longer prefers IPv4 over IPv6 for DNS lookups. E.g. It's not guaranteed that localhost will be resolved to 127.0.0.1 – it might just as well be ::1 (or some other IP address).
If your target server only accepts IPv4 connections, trying to proxy to localhost will fail if resolved to ::1 (IPv6).
Ways to solve it:
Change target: "http://localhost" to target: "http://127.0.0.1" (IPv4).

https://github.com/chimurai/http-proxy-middleware/blob/3aad7521473bcc182ca43fedb783df1efdedfe39/README.md#nodejs-17-econnrefused-issue-with-ipv6-and-localhost-705

We take the first solution.

This was painful, because the docker machine and our local machine's `/etc/hosts/` both map `localhost`  to `127.0.0.1`
```
❯ docker exec -it 07d36f421097 /bin/bash
root@07d36f421097:/app#
root@07d36f421097:/app#
root@07d36f421097:/app#
root@07d36f421097:/app# ls
Dockerfile  Procfile	  README.md    bin     docker-compose.override.yml  docs	 home	  manage.py	package-lock.json  poetry.lock	   pytest.ini	     runtime.txt  server
Makefile    Procfile.dev  __pycache__  client  docker-compose.yml	    example.env  htmlcov  node_modules	package.json	   pyproject.toml  requirements.txt  scripts	  static
root@07d36f421097:/app# cat /etc/hosts
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::0	ip6-localnet
ff00::0	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
172.19.0.3	07d36f421097
root@07d36f421097:/app#
```

Additionally, `curl http://localhost:8000/` also worked both in the docker machine and through the browser.