### PR TITLE
Fix Histogram api call to have client_id and start_date/end_date send separately

### DIFF
--- a/client/src/Api.js
+++ b/client/src/Api.js
@@ -94,15 +94,32 @@ const Api = {
       });
     },
     histogram({
-      path, field,
-      contest_id, is_tester,
-      start_date, end_date,
-      bin_size, bin_count, bin_custom,
+      path,
+      field,
+      contest_id,
+      is_tester,
+      start_date,
+      end_date,
+      bin_size,
+      bin_count,
+      bin_custom,
     }) {
+      if (contest_id) {
+        [start_date, end_date] = "";
+      }
       return instance.get(`/api/admin/${path}/histogram`, {
-        params: { contest_id, is_tester, field, start_date, end_date, bin_size, bin_count, bin_custom },
+        params: {
+          contest_id,
+          is_tester,
+          field,
+          start_date,
+          end_date,
+          bin_size,
+          bin_count,
+          bin_custom,
+        },
       });
-    }
+    },
   },
   static: {
     map() {


### PR DESCRIPTION
Related to Issue 205:

The frontend client when selecting "contest_id" was sending the contest start and end date into the API.

This causes a 422 as contest_id and start_end_date are mutually exclusive.

Changed the API call so that it doesn't send start/end date when client_id is not null and vice versa.

