### PR TITLE
fix: histogram issues for user age

### DIFF
--- a/client/src/Components/Histogram.js
+++ b/client/src/Components/Histogram.js
@@ -43,11 +43,14 @@ function Histogram({
                     bin_custom,
                 });
                 const { data, unit } = response.data;
-                !cancelled && setResp({
-                    data: transform(data, field),
-                    unit,
-                    bin_size,
-                });
+                if (!cancelled) {
+                    setError(null);
+                    setResp({
+                        data: transform(data, field),
+                        unit,
+                        bin_size,
+                    });
+                }
             } catch (error) {
                 !cancelled && setError(error)
             } finally {
@@ -88,13 +91,16 @@ function Histogram({
 }
 
 const transform = (data, field) => {
+    // Display a cutoff for the last bin,
+    // since the last bin is the upper limit.
+    const lastIdx = data.length - 1;
     return [
         [capitalize(field), "Count"],
         ...data.map(
-            ({ bin_start, bin_end, count }) => [
+            ({ bin_start, bin_end, count }, i) => [
                 // Subtract by 1 at the end since the ranges are exclusive, and we want to
                 // display them as inclusive.
-                bin_end ? `${bin_start}-${bin_end - 1}` : `>${bin_start}`,
+                (i !== lastIdx) ? `${bin_start}-${bin_end - 1}` : `>${bin_start}`,
                 count,
             ])
     ]

--- a/client/src/Components/Histogram.js
+++ b/client/src/Components/Histogram.js
@@ -30,6 +30,7 @@ function Histogram({
     useEffect(() => {
         let cancelled = false;
         setLoading(true);
+        setError(null);
         const fetchHistogram = async () => {
             try {
                 const response = await Api.admin.histogram({
@@ -44,7 +45,6 @@ function Histogram({
                 });
                 const { data, unit } = response.data;
                 if (!cancelled) {
-                    setError(null);
                     setResp({
                         data: transform(data, field),
                         unit,

--- a/client/src/Home.js
+++ b/client/src/Home.js
@@ -342,9 +342,10 @@ function Home() {
               path="users"
               field="age"
               bin_custom="18,30,45,60"
+              // contest_id and dates are mutually exclusive
               contest_id={contest_id}
-              start_date={start_date}
-              end_date={end_date}
+              start_date={contest_id ? undefined : start_date}
+              end_date={contest_id ? undefined : end_date}
               options={chartOptions.histogram}
               width="100%"
               height="400px"

--- a/home/tests/unit/test_histogram.py
+++ b/home/tests/unit/test_histogram.py
@@ -183,7 +183,7 @@ class TestHistogram(TestCase):
                 "expect": {
                     "response": {
                         "data": [],
-                        "unit": "steps", 
+                        "unit": "steps",
                         "bin_size": 10,
                     }
                 },

--- a/home/tests/unit/test_histogram.py
+++ b/home/tests/unit/test_histogram.py
@@ -181,7 +181,11 @@ class TestHistogram(TestCase):
                     "model": Leaderboard,
                 },
                 "expect": {
-                    "error": "No data found",
+                    "response": {
+                        "data": [],
+                        "unit": "steps", 
+                        "bin_size": 10,
+                    }
                 },
             },
             {

--- a/home/views/api/histogram/serializers.py
+++ b/home/views/api/histogram/serializers.py
@@ -247,7 +247,7 @@ class HistogramReqSerializer(serializers.Serializer):
         )
 
         upper, lower = range.get("max_value"), range.get("min_value")
-        if not upper or not lower: 
+        if not upper or not lower:
             # no data was found in the range.
             return {
                 "query_set": model.objects.none(),
@@ -255,7 +255,7 @@ class HistogramReqSerializer(serializers.Serializer):
                 "bin_custom": bin_custom,
                 "bin_size": bin_size,
                 "unit": self.unit,
-            } 
+            }
 
         if bin_count:
             # Using an offset because dividing by N equal parts
@@ -323,7 +323,7 @@ class HistogramReqSerializer(serializers.Serializer):
             def get_bin_end(bin_start):
                 idx_of_end = idx_lookup[bin_start] + 1
                 if idx_of_end >= len(bin_custom):
-                    return upper 
+                    return upper
                 return bin_custom[idx_of_end]
 
             def get_bin_idx(bin_start):

--- a/home/views/api/histogram/serializers.py
+++ b/home/views/api/histogram/serializers.py
@@ -231,7 +231,7 @@ class HistogramReqSerializer(serializers.Serializer):
         bin_count: int,
         bin_size: int,
         bin_custom: List[int],
-    ):
+    ) -> ValidatedHistogramReq:
         """Handle bin_count generates a histogram based on the bin_count."""
         date_filter: Q = self.get_date_filter(
             model=model,
@@ -247,10 +247,15 @@ class HistogramReqSerializer(serializers.Serializer):
         )
 
         upper, lower = range.get("max_value"), range.get("min_value")
-        if not upper or not lower:
-            raise serializers.ValidationError(
-                {"non_field_errors": "No data found for the given date range."}
-            )
+        if not upper or not lower: 
+            # no data was found in the range.
+            return {
+                "query_set": model.objects.none(),
+                "bin_count": bin_count,
+                "bin_custom": bin_custom,
+                "bin_size": bin_size,
+                "unit": self.unit,
+            } 
 
         if bin_count:
             # Using an offset because dividing by N equal parts
@@ -318,7 +323,7 @@ class HistogramReqSerializer(serializers.Serializer):
             def get_bin_end(bin_start):
                 idx_of_end = idx_lookup[bin_start] + 1
                 if idx_of_end >= len(bin_custom):
-                    return upper
+                    return upper 
                 return bin_custom[idx_of_end]
 
             def get_bin_idx(bin_start):


### PR DESCRIPTION
Fixes a few issues:

- There's a person who is 20 million years old, so for the end range, just display >60 instead of relying on the upper end.
- clear errors on new request
- remove the error message on "no data found", as it is valid to have no data found within a given date range

old: 
<img width="675" alt="image" src="https://github.com/sfbrigade/intentional-walk-server/assets/161795448/20f39c1d-b65e-47c9-8c75-a56c7e2d0bcb">
new:
<img width="718" alt="image" src="https://github.com/sfbrigade/intentional-walk-server/assets/161795448/31f4413a-f662-405d-99d9-435fd8839d45">
