### PR TITLE
fix: remove is_tester auto set

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -11,7 +11,7 @@ zip: the user's home zip code
 age: the user's self reported age  
 is_latino: enum of responses, see IsLatinoLabels in home/models/account.py  
 is_sf_resident: true/false if the zip code is in the list of SF zip codes  
-is_tester: true if the user is a tested, automatically set if the name includes Tester  
+is_tester: true if the user is a tester, manually set by administrators through the Django admin dashboard
 gender: enum of responses, see GenderLabels in home/models/account.py  
 gender_other: freeform text response if gender is Other  
 race: enum of responses, see RaceLabels in home/models/account.py  

--- a/home/tests/integration/appuser/test_create.py
+++ b/home/tests/integration/appuser/test_create.py
@@ -61,9 +61,11 @@ class ApiTestCase(TestCase):
                 getattr(user_obj, field), expected_value, msg=f"{field}"
             )
 
-    # Test creation of a new "Tester" app user
+    # is_tester should always default to false;
+    # We can only set is_tester through the admin panel.
     def test_create_tester_appuser_success(self):
-        # Set up request and response for a Tester user based in SF
+        # Set up request and response for a regular user based in SF
+        # who coincidentally has tester in their name.
         request_params = self.request_params.copy()
         request_params.update(
             {
@@ -76,7 +78,7 @@ class ApiTestCase(TestCase):
             {
                 "name": "Tester John",
                 "zip": "94105",
-                "is_tester": True,
+                "is_tester": False,
                 "is_sf_resident": True,
             }
         )

--- a/home/tests/unit/api/test_appuser.py
+++ b/home/tests/unit/api/test_appuser.py
@@ -1,24 +1,6 @@
 from django.test import TestCase
 
-from home.views.api.appuser import is_tester, validate_account_input
-
-
-class TestIsTester(TestCase):
-    def test_is_tester(self):
-        examples = [
-            ("Tester A", True),
-            ("Test B", False),  # are we sure this is the behavior we want?
-            ("tester c", True),
-            ("Testerosa", False),
-            ("tester-d", True),
-            ("Tester_E", True),
-            ("testrata", False),
-            ("tester", False),  # are we sure this is the behavior we want?
-        ]
-        for example, expected in examples:
-            self.assertEqual(
-                expected, is_tester(example), f"failed '{example}'"
-            )
+from home.views.api.appuser import validate_account_input
 
 
 class TestValidateAccountInput(TestCase):

--- a/home/views/api/appuser.py
+++ b/home/views/api/appuser.py
@@ -18,14 +18,6 @@ from home.models.account import (
 from .utils import validate_request_json
 
 
-# Determines whether Account is tester account, based on name prefix
-def is_tester(name_field: str) -> bool:
-    possible_prefixes = ["tester-", "tester ", "tester_"]
-    return any(
-        [name_field.lower().startswith(prefix) for prefix in possible_prefixes]
-    )
-
-
 # Validates Account input data. Raises AssertionError if field is invalid.
 # Does not check for required fields since that is done by
 # validate_request_json
@@ -119,7 +111,6 @@ def update_account(acct: Account, data: dict):
     # Not possible to update email
     if data.get("name") is not None:
         acct.name = data["name"]
-        acct.is_tester = is_tester(data["name"])
 
     if data.get("zip") is not None:
         acct.zip = data["zip"]
@@ -236,7 +227,6 @@ class AppUserCreateView(View):
                     name=json_data["name"],
                     zip=json_data["zip"],
                     age=json_data["age"],
-                    is_tester=is_tester(json_data["name"]),
                     is_sf_resident=json_data["zip"] in SAN_FRANCISCO_ZIP_CODES,
                 )
                 account_updated = False


### PR DESCRIPTION
We can just use the Django admin dashboard ui to toggle is_tester, since I don't foresee a need for bulk is_tester or frequent changes.

<img width="452" alt="image" src="https://github.com/sfbrigade/intentional-walk-server/assets/161795448/44ad11e4-769b-43af-952a-fe32e118684a">


ASANA: https://app.asana.com/0/1201140011812889/1207388002688883/f