### PR TITLE
fix: heat map issue

### DIFF
--- a/client/src/Components/IntensityMap.js
+++ b/client/src/Components/IntensityMap.js
@@ -21,10 +21,21 @@ function IntensityMap({
         .center([-122.44, 37.76])
         .translate([width / 2, height / 2]);
 
+      // The largest value could still be 0 ...
+      const maxDataValue = Math.floor(
+        Math.max(...Object.values(data))
+      );
+
+      // Ensure the upperLimit is at least greater than 0,
+      // so that we don't have a scale of [0, 0]
+      const upperLimit = Math.max(
+        maxDataValue,
+        1,
+      )
       // set up color gradient
       const colorScale = d3
         .scaleLinear()
-        .domain([1, Math.floor(Math.max(...Object.values(data)))])
+        .domain([0, upperLimit])
         .range([minColor, maxColor]);
 
       // draw map
@@ -37,7 +48,9 @@ function IntensityMap({
         .append("path")
         // draw each neighborhood
         .attr("d", d3.geoPath().projection(projection))
-        .attr("stroke", "#f0f0f0")
+        // use a dark stroke so that even when the value for a region is empty (0), there
+        // is still a visible outline of the neighborhood.
+        .attr("stroke", "#000000")
         .attr("fill", (feature) => colorScale(data[feature.id] ?? 0))
         .on("mouseover", (_, feature) => onMouseOver(feature))
         .on("mouseout", () => onMouseOver());


### PR DESCRIPTION
Heat map isn't correctly rendering for when data is 0.

This is because the scale is incorrect (starting at 1 to max of data) which can end up being [1, 0] when data starts.

Correctly fix to [0, 1] at least, and adjust the UI so we can see the borders.
<img width="1399" alt="image" src="https://github.com/sfbrigade/intentional-walk-server/assets/161795448/cf278345-2b3b-4a03-93be-a6ab4bac28b4">


ASANA: https://app.asana.com/0/1201140011812889/1207387759617792/f