### PR TITLE
fix: handle empty users for histogram of age for new contests

### DIFF
--- a/client/src/Components/Histogram.js
+++ b/client/src/Components/Histogram.js
@@ -78,17 +78,21 @@ function Histogram({
     return (
         <>
             <h3>{pathToTitle(path, field, resp.unit)}</h3>
-            <Chart
-                // Because we have pre-binned data.
-                chartType="ColumnChart"
-                data={resp.data}
-                options={options}
-                width={width}
-                height={height}
-            />
+
+            {
+                // The header is the first entry, the rest are 
+                // the bins. This indicates that there is data. 
+                (resp.data.length > 1) ? <Chart
+                    // Because we have pre-binned data.
+                    chartType="ColumnChart"
+                    data={resp.data}
+                    options={options}
+                    width={width}
+                    height={height}
+                /> : <p>No data available.</p>}
         </>
     );
-}
+};
 
 const transform = (data, field) => {
     // Display a cutoff for the last bin,

--- a/home/tests/unit/test_histogram.py
+++ b/home/tests/unit/test_histogram.py
@@ -39,6 +39,20 @@ class TestHistogram(TestCase):
                 },
             },
             {
+                "name": "empty contest with no user",
+                "input": {
+                    "field": "age",
+                    "bin_size": 10,
+                    "model": Account,
+                    "contest_id": self.empty_contest_id,
+                },
+                "expect": {
+                    "response": {
+                        "data": [],
+                    }
+                },
+            },
+            {
                 "name": "require contest id data for Leaderboard",
                 "input": {
                     "field": "steps",

--- a/home/views/api/admin.py
+++ b/home/views/api/admin.py
@@ -616,7 +616,7 @@ class AdminHistogramView(View):
         query_set,
         bin_size: int = None,
         bin_custom: list = None,
-        total_bin_ct: int = None,
+        total_bin_ct: int = 0,
     ):
         """Fill in missing bin intervals lazily.
 
@@ -662,7 +662,7 @@ class AdminHistogramView(View):
         cursor = next(bin_idx_counter)
         # Fill in the rest of the bins with 0 count,
         # until we reach the total expected count of bins.
-        while cursor < total_bin_ct:
+        while cursor and cursor < total_bin_ct:
             yield create_filler(
                 cursor=cursor, bin_size=bin_size, bin_custom=bin_custom
             )


### PR DESCRIPTION
The current contest has no users, and we weren't handling that properly in the contest graph.

Changes a few fields to support it by displaying a No data found and adding an extra check when the cursor is None (while trying to hit next on an empty set).