### PR TITLE
fix: csrf issue and loading static files on localhost:3000 admin page

### DIFF
--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -2,7 +2,7 @@ const { createProxyMiddleware } = require("http-proxy-middleware");
 
 module.exports = function (app) {
   app.use(
-    ["/admin", "/api", "/static/home"],
+    ["/admin", "/api", "/static/home", "/static/admin"],
     createProxyMiddleware({
       target: "http://127.0.0.1:8000",
       changeOrigin: true,

--- a/server/settings.py
+++ b/server/settings.py
@@ -180,5 +180,6 @@ LOGGING = {
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
-# Add trusted origins
-CSRF_TRUSTED_ORIGINS = [f"http://localhost:3000"]
+# React client is on 3000, while django admin auth is on 8000
+if os.getenv("DEPLOY_ENV") == "development":
+   CSRF_TRUSTED_ORIGINS = ["http://localhost:3000", "http://127.0.0.1:3000"]

--- a/server/settings.py
+++ b/server/settings.py
@@ -179,3 +179,6 @@ LOGGING = {
 }
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
+# Add trusted origins
+CSRF_TRUSTED_ORIGINS = [f"http://localhost:3000"]


### PR DESCRIPTION
Resolves CSRF issue when logging in to localhost:3000 due to having two admin pages and using a proxy. Fixed by including localhost:3000 as trusted origin in settings.py

Also resolved static CSSs and JS files from loading due to using a proxy. Fixed by including /static/admin path in proxy.