### PR TITLE
Update postgres14.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.11.4
+FROM python:3.11.9-bookworm
 ENV PATH="/root/.local/bin:${PATH}"
 
 # Install postgres client
 RUN wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O - | apt-key add - && \
-    echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" >> /etc/apt/sources.list.d/pgdg.list && \
+    echo "deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main" >> /etc/apt/sources.list.d/pgdg.list && \
     apt-get update -y && \
-    apt-get install -y postgresql-client-12 tzdata && \
+    apt-get install -y postgresql-client-14 tzdata && \
     curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -20,6 +20,6 @@ services:
     ports:
       - "8001:8001"
   db:
-    image: postgres:12
+    image: postgres:14.12
     ports:
       - 5433:5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   db:
-    image: postgres:12
+    image: postgres:14.12
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:


### PR DESCRIPTION
Dev environment's Docker image is still running Postgres 12, which has reached end of life.

Changed Postgres version from 12 to 14.12 in docker-compose.yml and docker-compose.override.yml files to match version running in production.