### PR TITLE
scrub database dump: implement private fields for classes 

### DIFF
--- a/home/models/__init__.py
+++ b/home/models/__init__.py
@@ -5,3 +5,13 @@ from .device import Device
 from .intentionalwalk import IntentionalWalk
 from .leaderboard import Leaderboard
 from .weeklygoal import WeeklyGoal
+
+ALL_MODELS = [
+    Account,
+    Contest,
+    DailyWalk,
+    Device,
+    IntentionalWalk,
+    Leaderboard,
+    WeeklyGoal,
+]

--- a/home/models/account.py
+++ b/home/models/account.py
@@ -1,7 +1,14 @@
 from enum import Enum
+from typing import List
 
 from django.db import models
 from setfield import SetField
+
+from home.models.mixins.privacyprotectedfields import (
+    PrivacyProtectedFieldsMixin,
+    PrivateFieldInfo,
+    FieldType,
+)
 
 SAN_FRANCISCO_ZIP_CODES = set(
     [
@@ -72,7 +79,7 @@ class IsLatinoLabels(Enum):
 
 
 # Note: Maybe inherit from Django's User model?
-class Account(models.Model):
+class Account(models.Model, PrivacyProtectedFieldsMixin):
     """
     Stores a single user account as identified by email. This is created when
     the app is installed and the user signs up for the first time and is has
@@ -149,6 +156,14 @@ class Account(models.Model):
 
     def __str__(self):
         return f"{self.name} | {self.email}"
+
+    @staticmethod
+    def privacy_protected_fields() -> List[PrivateFieldInfo]:
+        """Privacy protected fields overrides the PrivacyProtectedFields mixin.c"""
+        return [
+            PrivateFieldInfo(name="email", type=FieldType.EMAIL),
+            PrivateFieldInfo(name="name", type=FieldType.NAME),
+        ]
 
     class Meta:
         ordering = ("-created",)

--- a/home/models/mixins/privacyprotectedfields.py
+++ b/home/models/mixins/privacyprotectedfields.py
@@ -1,0 +1,38 @@
+from typing import List, TypedDict
+from enum import Enum
+
+
+class FieldType(Enum):
+    """Represents data types for Faker to generate."""
+
+    EMAIL = "email"
+    NAME = "name"
+
+
+class PrivateFieldInfo(TypedDict):
+    """Represents a sensitive field in a model."""
+
+    name: str
+    type: FieldType
+
+
+class PrivacyProtectedFieldsMixin:
+    """Mixin to define sensitive fields in a model.
+
+    A downstream handler for a Model that extends this mixin should
+    implement the `privacy_protected_fields` method to return the list of
+    sensitive fields that should be scrubbed, hidden away or otherwise excluded.
+
+    Example use:
+    ```python
+    class Account(models.Model, PrivacyProtectedFieldsMixin):
+        email = models.EmailField()
+        def privacy_protected_fields():
+            return ["email", "name"]
+    ```
+    """
+
+    @staticmethod
+    def privacy_protected_fields() -> List[PrivateFieldInfo]:
+        """Return a list of sensitive fields in the model."""
+        raise NotImplementedError

--- a/home/tests/unit/api/test_appuser.py
+++ b/home/tests/unit/api/test_appuser.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
 
+from home.models.account import Account
+from home.models.mixins.privacyprotectedfields import PrivacyProtectedFieldsMixin
 from home.views.api.appuser import is_tester, validate_account_input
 
 
@@ -64,3 +66,10 @@ class TestValidateAccountInput(TestCase):
         for example in examples:
             with self.assertRaises(AssertionError, msg=example):
                 validate_account_input(example)
+
+    def test_private(self):
+        # Just ensure the method is implemented,
+        # mainly for test coverage.
+        self.assertTrue(issubclass(Account, PrivacyProtectedFieldsMixin))
+        items = Account.privacy_protected_fields()
+        self.assertGreater(len(items), 0)

--- a/home/tests/unit/api/test_appuser.py
+++ b/home/tests/unit/api/test_appuser.py
@@ -1,7 +1,9 @@
 from django.test import TestCase
 
 from home.models.account import Account
-from home.models.mixins.privacyprotectedfields import PrivacyProtectedFieldsMixin
+from home.models.mixins.privacyprotectedfields import (
+    PrivacyProtectedFieldsMixin,
+)
 from home.views.api.appuser import is_tester, validate_account_input
 
 


### PR DESCRIPTION
Scrubbing Database Dump

Part 1 | Part 2 

Implements the first part of creating a scrub database dump script is to allow models to declare which fields are sensitive and scrubbed.

Models that have this should extend the interface by inheriting the mixin class and overriding the `privacy_protected_method` method. The types are mapped to `Faker` fake function implementations.


