### PR TITLE
fix: add chaining [Closes #236]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,9 @@ jobs:
           # git config --global --add safe.directory /app
           command: |
             docker-compose -p iwalk exec -e COVERALLS_REPO_TOKEN server bash -c "
-              git config --global --add safe.directory /app 
-              make test
-              make coverage
+              git config --global --add safe.directory /app && \ 
+              make test && \
+              make coverage && \
               poetry run coveralls
             "
 workflows:

--- a/home/tests/unit/api/test_appuser.py
+++ b/home/tests/unit/api/test_appuser.py
@@ -9,10 +9,10 @@ class TestIsTester(TestCase):
             ("Iwt A", True),
             ("Test B", False),
             ("iwt c", True),
-            ("Iwterosa", False),
+            ("Iwterosa", True),
             ("iwt-d", True),
             ("Iwt_E", True),
-            ("iwtrata", False),
+            ("iwtrata", True),
             ("iwt", True),
         ]
         for example, expected in examples:

--- a/home/views/api/appuser.py
+++ b/home/views/api/appuser.py
@@ -20,7 +20,7 @@ from .utils import validate_request_json
 
 # Determines whether Account is tester account, based on name prefix
 def is_tester(name_field: str) -> bool:
-    possible_prefixes = ["iwt "]
+    possible_prefixes = ["iwt"]
     return any(
         [name_field.lower().startswith(prefix) for prefix in possible_prefixes]
     )


### PR DESCRIPTION
Issue #236 

Adds `&&` chaining so we get failures early from CI.

I adjust the tests to match. Not sure if I captured the behavior. Is the prefix just "iwt"?

@JimmiHagen 
